### PR TITLE
Log messages through the Unix system logger.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+# Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+# Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -29,7 +29,7 @@ $(SRV):
 $(JAR):
 	$(LEIN) $(UBERJAR) && \
 	DAEMON_NAME="customers-api-lite"; \
-	DMN_VERSION="0.0.2"; \
+	DMN_VERSION="0.0.3"; \
 	SIMPLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}.jar"; \
 	BUNDLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}-standalone.jar"; \
 	$(RM) $${SIMPLE_JAR} && $(MV) $${BUNDLE_JAR} $${SIMPLE_JAR} && \

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $
 $ lein uberjar && \
   UBERJAR_DIR="target/uberjar"; \
   DAEMON_NAME="customers-api-lite"; \
-  DMN_VERSION="0.0.2"; \
+  DMN_VERSION="0.0.3"; \
   SIMPLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}.jar"; \
   BUNDLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}-standalone.jar"; \
   rm ${SIMPLE_JAR} && mv ${BUNDLE_JAR} ${SIMPLE_JAR} && \
@@ -65,8 +65,8 @@ $ lein uberjar && \
   fi
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.2.jar
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.2-standalone.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.3.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.3-standalone.jar
 ```
 
 Or **build** the microservice using **GNU Make** (optional, but for convenience &mdash; it covers the same **Leiningen** build workflow under the hood):
@@ -92,14 +92,14 @@ $ lein run; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `uberjar` Leiningen task or GNU Make's `all` target:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.0.2.jar; echo $?
+$ java -jar target/uberjar/customers-api-lite-0.0.3.jar; echo $?
 ...
 ```
 
 To run the microservice as a *true* daemon, i.e. in the background, redirecting all the console output to `/dev/null`, the following form of invocation of its executable JAR bundle can be used:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.0.2.jar > /dev/null 2>&1 &
+$ java -jar target/uberjar/customers-api-lite-0.0.3.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+-- Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+-- Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+-- Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+-- Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+; Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype
@@ -10,7 +10,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject customers-api-lite "0.0.2"
+(defproject customers-api-lite "0.0.3"
     :description     "Customers API Lite microservice prototype."
     :url             "https://github.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit"
     :license {

--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,8 @@
         [org.clojure/clojure       "1.12.3"]
         [org.clojure/tools.logging "1.3.0" ]
         [org.slf4j/slf4j-reload4j  "2.0.17"]
+        [org.graylog2/syslog4j     "0.9.61"]
+        [net.java.dev.jna/jna      "5.18.0"]
         [http-kit                  "2.8.1" ]
     ]
     :main ^:skip-aot customers.api-lite.core

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -11,7 +11,10 @@
 ;
 
 (ns customers.api-lite.core "The main namespace of the daemon." (:gen-class)
-    (:use [customers.api-lite.helper]))
+    (:use    [customers.api-lite.helper])
+    (:import (org.graylog2.syslog4j.impl.unix UnixSyslogConfig)
+             (org.graylog2.syslog4j.impl.unix UnixSyslog      )
+             (org.graylog2.syslog4j           SyslogIF        )))
 
 (defn -main
     "The microservice entry point.
@@ -22,7 +25,17 @@
 
     (let [dbg true]
 
-    (-dbg dbg (str (O_BRACKET) (DAEMON_NAME) (C_BRACKET))))
+    ; Opening the system logger.
+    ; Calling <syslog.h> openlog(NULL, LOG_CONS | LOG_PID, LOG_DAEMON);
+    (let [cfg (UnixSyslogConfig.)]
+    (.setIdent cfg nil) (.setFacility cfg SyslogIF/FACILITY_DAEMON)
+    (let [s (UnixSyslog.)] (.initialize s SyslogIF/UNIX_SYSLOG cfg)
+
+    (-dbg dbg s (str (O_BRACKET) (DAEMON_NAME) (C_BRACKET)))
+
+    ; Closing the system logger.
+    ; Calling <syslog.h> closelog();
+    (.shutdown s))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -33,9 +33,7 @@
 
     (-dbg dbg s (str (O_BRACKET) (DAEMON_NAME) (C_BRACKET)))
 
-    ; Closing the system logger.
-    ; Calling <syslog.h> closelog();
-    (.shutdown s))))
+    (-cleanup s))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/core.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+; Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -20,10 +20,11 @@
 (defmacro DAEMON_NAME "The daemon name." [] "Customers API Lite")
 
 ; Helper function. Used to log messages for debugging aims in a free form.
-(defn -dbg [dbg message]
-    (if dbg
-        (l/debug message)
-    )
+(defn -dbg [dbg s message]
+    (if dbg (do
+        (l/debug  message)
+        (.debug s message)
+    ))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/helper.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+; Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -27,4 +27,11 @@
     ))
 )
 
+; Helper function. Makes final cleanups, closes streams, etc.
+(defn -cleanup [s]
+    ; Closing the system logger.
+    ; Calling <syslog.h> closelog();
+    (.shutdown s)
+)
+
 ; vim:set nu et ts=4 sw=4:

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.0.2
+# Customers API Lite microservice prototype (Clojure port). Version 0.0.3
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- Adding dependency: `org.graylog2/syslog4j` (**Syslog4j Graylog2**) to log messages through the **Unix system logger** and `net.java.dev.jna/jna` (**JNA &mdash; Java Native Access**) as a runtime dependency to **Syslog4j**.
- Log messages through the **Unix system logger**.
- Closing the **Unix system logger** using a _special helper function_ that will be expanded to other actions in the future.
- Bumping version number to **0.0.3**.