### PR TITLE
Start up the http-kit web server on the port provided. (Stop it gracefully.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+# Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+# Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -29,7 +29,7 @@ $(SRV):
 $(JAR):
 	$(LEIN) $(UBERJAR) && \
 	DAEMON_NAME="customers-api-lite"; \
-	DMN_VERSION="0.0.5"; \
+	DMN_VERSION="0.0.6"; \
 	SIMPLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}.jar"; \
 	BUNDLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}-standalone.jar"; \
 	$(RM) $${SIMPLE_JAR} && $(MV) $${BUNDLE_JAR} $${SIMPLE_JAR} && \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $
 $ lein uberjar && \
   UBERJAR_DIR="target/uberjar"; \
   DAEMON_NAME="customers-api-lite"; \
-  DMN_VERSION="0.0.5"; \
+  DMN_VERSION="0.0.6"; \
   SIMPLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}.jar"; \
   BUNDLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}-standalone.jar"; \
   rm ${SIMPLE_JAR} && mv ${BUNDLE_JAR} ${SIMPLE_JAR} && \
@@ -66,8 +66,8 @@ $ lein uberjar && \
   fi
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.5.jar
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.5-standalone.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.6.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.6-standalone.jar
 ```
 
 Or **build** the microservice using **GNU Make** (optional, but for convenience &mdash; it covers the same **Leiningen** build workflow under the hood):
@@ -93,14 +93,14 @@ $ lein run; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `uberjar` Leiningen task or GNU Make's `all` target:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.0.5.jar; echo $?
+$ java -jar target/uberjar/customers-api-lite-0.0.6.jar; echo $?
 ...
 ```
 
 To run the microservice as a *true* daemon, i.e. in the background, redirecting all the console output to `/dev/null`, the following form of invocation of its executable JAR bundle can be used:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.0.5.jar > /dev/null 2>&1 &
+$ java -jar target/uberjar/customers-api-lite-0.0.6.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 
@@ -111,7 +111,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.0.5.jar > /dev/null 2>&1
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.0.6.jar > /dev/null 2>&1
 ```
 
 ## Consuming

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ $ java -jar target/uberjar/customers-api-lite-0.0.5.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 
+**Note:** This will suppress all the console output only; logging to a logfile and to the Unix syslog will remain unchanged.
+
+The daemonized microservice then can be stopped gracefully at any time by issuing the following command:
+
+```
+$ kill -SIGTERM <pid>
+$
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.0.5.jar > /dev/null 2>&1
+```
+
 ## Consuming
 
 The microservice *should* expose **six REST API endpoints** to web clients... They are all intended to deal with customer entities and/or contact entities that belong to customer profiles. The following table displays their syntax:

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+-- Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+-- Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+-- Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+-- Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+; Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype
@@ -10,7 +10,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject customers-api-lite "0.0.5"
+(defproject customers-api-lite "0.0.6"
     :description     "Customers API Lite microservice prototype."
     :url             "https://github.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit"
     :license {

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -21,7 +21,7 @@
               (org.graylog2.syslog4j           SyslogIF        )))
 
 (defn- -req-handler [req]
-    (l/debug (str (O-BRACKET) req (C-BRACKET)))
+    (-dbg (str (O-BRACKET) req (C-BRACKET)))
 )
 
 (defn -main
@@ -35,13 +35,13 @@
     (let [settings (-get-settings)]
 
     ; Identifying whether debug logging is enabled.
-    (let [dbg (get settings :logger.debug.enabled)]
+    (reset! dbg (get settings :logger.debug.enabled))
 
     ; Opening the system logger.
     ; Calling <syslog.h> openlog(NULL, LOG_CONS | LOG_PID, LOG_DAEMON);
     (let [cfg (UnixSyslogConfig.)]
     (.setIdent cfg nil) (.setFacility cfg SyslogIF/FACILITY_DAEMON)
-    (let [s (UnixSyslog.)] (.initialize s SyslogIF/UNIX_SYSLOG cfg)
+    (reset! s(UnixSyslog.))(.initialize@s SyslogIF/UNIX_SYSLOG cfg))
 
     (let [daemon-name (get settings :daemon.name)]
 
@@ -49,18 +49,18 @@
     (let [server-port (-get-server-port settings)]
 
     ; Getting the SQLite database path.
-    (let [database-path (get settings :sqlite.database.path)]
+    (let [database-path (get settings :sqlite.database.path)])
 
-    (-dbg dbg s (str (O-BRACKET) daemon-name (C-BRACKET)))
+    (-dbg (str (O-BRACKET) daemon-name (C-BRACKET)))
 
     (l/info  (str (MSG-SERVER-STARTED) server-port))
-    (.info s (str (MSG-SERVER-STARTED) server-port))
+    (.info@s (str (MSG-SERVER-STARTED) server-port))
 
     ; Starting up the http-kit web server.
-    (let [server (run-server -req-handler {:port server-port})]
+    (let [server (run-server -req-handler {:port server-port})])
 
     ; FIXME: Call (-cleanup) on SIGTERM / INT, not here.
-    (-cleanup s)))))))))
+    (-cleanup))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/core.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+; Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -19,6 +19,10 @@
               [org.httpkit.server :refer  [
                   run-server
                   server-status
+                  server-stop!
+              ]]
+              [clojure.repl       :refer  [
+                  set-break-handler!
               ]]))
 
 (defn- -req-handler [req]
@@ -65,10 +69,15 @@
         (.info@s (str (MSG-SERVER-STARTED) server-port))
 
         (-dbg (str (O-BRACKET) (server-status server) (C-BRACKET)))
-    )))))
+    ))
 
-    ; FIXME: Call (-cleanup) on SIGTERM / INT, not here.
-;   (-cleanup)
+    (set-break-handler! (fn [_]
+        (-dbg (str (O-BRACKET) (server-status server) (C-BRACKET)))
+
+        (-cleanup)
+
+        (server-stop! server)
+    )))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -18,6 +18,7 @@
     (:require [clojure.tools.logging :as l]
               [org.httpkit.server :refer  [
                   run-server
+                  server-status
               ]]))
 
 (defn- -req-handler [req]
@@ -53,14 +54,21 @@
     ; Getting the port number used to run the http-kit web server.
     (let [server-port (-get-server-port settings)]
 
-    (l/info  (str (MSG-SERVER-STARTED) server-port))
-    (.info@s (str (MSG-SERVER-STARTED) server-port))
-
     ; Starting up the http-kit web server.
-    (let [server (run-server -req-handler {:port server-port})])))
+    (let [server (run-server -req-handler {
+        :port                 server-port
+        :legacy-return-value? false
+    })]
+
+    (if (instance? org.httpkit.server.HttpServer server) (do
+        (l/info  (str (MSG-SERVER-STARTED) server-port))
+        (.info@s (str (MSG-SERVER-STARTED) server-port))
+
+        (-dbg (str (O-BRACKET) (server-status server) (C-BRACKET)))
+    )))))
 
     ; FIXME: Call (-cleanup) on SIGTERM / INT, not here.
-    (-cleanup)
+;   (-cleanup)
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -20,9 +20,6 @@
                   run-server
                   server-status
                   server-stop!
-              ]]
-              [clojure.repl       :refer  [
-                  set-break-handler!
               ]]))
 
 (defn- -req-handler [req]
@@ -71,25 +68,21 @@
         (-dbg (str (O-BRACKET) (server-status server) (C-BRACKET)))
     ))
 
-;;  (.addShutdownHook (Runtime/getRuntime) (Thread. #(
-;;      (l/debug "---.addShutdownHook")
-;;
-;;      (-cleanup)
-;;
-;;      (l/debug (str "---.addShutdownHook" (server-status server)))
-;;
-;;      (server-stop! server)
-;;  )))
-
-    (set-break-handler! (fn [_]
-        (l/debug "---set-break-handler!")
+    ; Trapping SIGINT / SIGTERM signals by adding a shutdown hook,
+    ; just as it can be written in pure Java:
+    ; Runtime.getRuntime().addShutdownHook(new Thread() {
+    ;     @Override
+    ;     public void run() {...}
+    ; });
+    (.addShutdownHook (Runtime/getRuntime) (Thread. #(
+        (l/debug "---.addShutdownHook")
 
         (-cleanup)
 
-        (l/debug (str "---set-break-handler!" (server-status server)))
+        (l/debug (str "---.addShutdownHook" (server-status server)))
 
         (server-stop! server)
-    )))))
+    ))))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -61,11 +61,11 @@
         :legacy-return-value? false
     })]
 
-    (if (instance? org.httpkit.server.HttpServer server) (do
+    (if (and (instance? org.httpkit.server.HttpServer server)
+        (= (server-status server) :running)) (do
+
         (l/info  (str (MSG-SERVER-STARTED) server-port))
         (.info@s (str (MSG-SERVER-STARTED) server-port))
-
-        (-dbg (str (O-BRACKET) (server-status server) (C-BRACKET)))
     ))
 
     ; Trapping SIGINT / SIGTERM signals by adding a shutdown hook,
@@ -75,12 +75,7 @@
     ;     public void run() {...}
     ; });
     (.addShutdownHook (Runtime/getRuntime) (Thread. #(
-        (l/debug "---.addShutdownHook")
-
         (-cleanup)
-
-        (l/debug (str "---.addShutdownHook" (server-status server)))
-
         (server-stop! server)
     ))))))
 )

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -71,10 +71,22 @@
         (-dbg (str (O-BRACKET) (server-status server) (C-BRACKET)))
     ))
 
+;;  (.addShutdownHook (Runtime/getRuntime) (Thread. #(
+;;      (l/debug "---.addShutdownHook")
+;;
+;;      (-cleanup)
+;;
+;;      (l/debug (str "---.addShutdownHook" (server-status server)))
+;;
+;;      (server-stop! server)
+;;  )))
+
     (set-break-handler! (fn [_]
-        (-dbg (str (O-BRACKET) (server-status server) (C-BRACKET)))
+        (l/debug "---set-break-handler!")
 
         (-cleanup)
+
+        (l/debug (str "---set-break-handler!" (server-status server)))
 
         (server-stop! server)
     )))))

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -11,11 +11,18 @@
 ;
 
 (ns customers.api-lite.core "The main namespace of the daemon." (:gen-class)
-    (:require [clojure.tools.logging :as l])
+    (:require [clojure.tools.logging :as l]
+              [org.httpkit.server :refer  [
+                  run-server
+              ]])
     (:use     [customers.api-lite.helper  ])
     (:import  (org.graylog2.syslog4j.impl.unix UnixSyslogConfig)
               (org.graylog2.syslog4j.impl.unix UnixSyslog      )
               (org.graylog2.syslog4j           SyslogIF        )))
+
+(defn- -req-handler [req]
+    (l/debug (str (O-BRACKET) req (C-BRACKET)))
+)
 
 (defn -main
     "The microservice entry point.
@@ -49,10 +56,11 @@
     (l/info  (str (MSG-SERVER-STARTED) server-port))
     (.info s (str (MSG-SERVER-STARTED) server-port))
 
-    ; TODO: Try to start up the http-kit web server.
-    ; .....
+    ; Starting up the http-kit web server.
+    (let [server (run-server -req-handler {:port server-port})]
 
-    (-cleanup s))))))))
+    ; FIXME: Call (-cleanup) on SIGTERM / INT, not here.
+    (-cleanup s)))))))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -11,14 +11,14 @@
 ;
 
 (ns customers.api-lite.core "The main namespace of the daemon." (:gen-class)
+    (:import  (org.graylog2.syslog4j.impl.unix UnixSyslogConfig)
+              (org.graylog2.syslog4j.impl.unix UnixSyslog      )
+              (org.graylog2.syslog4j           SyslogIF        ))
+    (:use     [customers.api-lite.helper  ])
     (:require [clojure.tools.logging :as l]
               [org.httpkit.server :refer  [
                   run-server
-              ]])
-    (:use     [customers.api-lite.helper  ])
-    (:import  (org.graylog2.syslog4j.impl.unix UnixSyslogConfig)
-              (org.graylog2.syslog4j.impl.unix UnixSyslog      )
-              (org.graylog2.syslog4j           SyslogIF        )))
+              ]]))
 
 (defn- -req-handler [req]
     (-dbg (str (O-BRACKET) req (C-BRACKET)))
@@ -31,36 +31,36 @@
         args: A vector of command-line arguments."
     {:added "0.0.1"} [& args]
 
-    ; Getting the daemon settings.
-    (let [settings (-get-settings)]
-
-    ; Identifying whether debug logging is enabled.
-    (reset! dbg (get settings :logger.debug.enabled))
-
     ; Opening the system logger.
     ; Calling <syslog.h> openlog(NULL, LOG_CONS | LOG_PID, LOG_DAEMON);
     (let [cfg (UnixSyslogConfig.)]
     (.setIdent cfg nil) (.setFacility cfg SyslogIF/FACILITY_DAEMON)
     (reset! s(UnixSyslog.))(.initialize@s SyslogIF/UNIX_SYSLOG cfg))
 
+    ; Getting the daemon settings.
+    (let [settings (-get-settings)]
+
+    ; Identifying whether debug logging is enabled.
+    (reset! dbg (get settings :logger.debug.enabled))
+
     (let [daemon-name (get settings :daemon.name)]
 
-    ; Getting the port number used to run the http-kit web server.
-    (let [server-port (-get-server-port settings)]
+    (-dbg (str (O-BRACKET) daemon-name (C-BRACKET))))
 
     ; Getting the SQLite database path.
     (let [database-path (get settings :sqlite.database.path)])
 
-    (-dbg (str (O-BRACKET) daemon-name (C-BRACKET)))
+    ; Getting the port number used to run the http-kit web server.
+    (let [server-port (-get-server-port settings)]
 
     (l/info  (str (MSG-SERVER-STARTED) server-port))
     (.info@s (str (MSG-SERVER-STARTED) server-port))
 
     ; Starting up the http-kit web server.
-    (let [server (run-server -req-handler {:port server-port})])
+    (let [server (run-server -req-handler {:port server-port})])))
 
     ; FIXME: Call (-cleanup) on SIGTERM / INT, not here.
-    (-cleanup))))
+    (-cleanup)
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/helper.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+; Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -35,6 +35,10 @@
 (defmacro MAX-PORT "The maximum port number allowed." [] 49151)
 (defmacro DEF-PORT "The default server port number."  [] 8080 )
 
+; Globals.
+(def s   "The Unix system logger."    (atom {}))
+(def dbg "The debug logging enabler." (atom {}))
+
 ; Helper function. Used to get the daemon settings.
 (defn -get-settings [] (edn/read-string (slurp (io/resource (SETTINGS)))))
 
@@ -55,21 +59,21 @@
 )
 
 ; Helper function. Used to log messages for debugging aims in a free form.
-(defn -dbg [dbg s message]
-    (if dbg (do
+(defn -dbg [message]
+    (if @dbg (do
         (l/debug  message)
-        (.debug s message)
+        (.debug@s message)
     ))
 )
 
 ; Helper function. Makes final cleanups, closes streams, etc.
-(defn -cleanup [s]
+(defn -cleanup []
     (l/info  (MSG-SERVER-STOPPED))
-    (.info s (MSG-SERVER-STOPPED))
+    (.info@s (MSG-SERVER-STOPPED))
 
     ; Closing the system logger.
     ; Calling <syslog.h> closelog();
-    (.shutdown s)
+    (.shutdown@s)
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+# Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -1,7 +1,7 @@
 ;
 ; src/resources/settings.conf
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.5
+; Customers API Lite microservice prototype (Clojure port). Version 0.0.6
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- Starting up the **http-kit web server** on the port provided.
- Adding globals: the **Unix system logger** and the **debug logging enabler**.
- Trapping and handling `SIGINT` / `SIGTERM` signals by adding a shutdown hook _using a standard Java approach for that_.
- Showing in the docs how to stop the daemonized microservice _gracefully_.
- Bumping version number to **0.0.6**.