### PR TITLE
Try to start up the http-kit web server, specifically catching and handling exceptions (if any).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -29,7 +29,7 @@ $(SRV):
 $(JAR):
 	$(LEIN) $(UBERJAR) && \
 	DAEMON_NAME="customers-api-lite"; \
-	DMN_VERSION="0.0.6"; \
+	DMN_VERSION="0.1.0"; \
 	SIMPLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}.jar"; \
 	BUNDLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}-standalone.jar"; \
 	$(RM) $${SIMPLE_JAR} && $(MV) $${BUNDLE_JAR} $${SIMPLE_JAR} && \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $
 $ lein uberjar && \
   UBERJAR_DIR="target/uberjar"; \
   DAEMON_NAME="customers-api-lite"; \
-  DMN_VERSION="0.0.6"; \
+  DMN_VERSION="0.1.0"; \
   SIMPLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}.jar"; \
   BUNDLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}-standalone.jar"; \
   rm ${SIMPLE_JAR} && mv ${BUNDLE_JAR} ${SIMPLE_JAR} && \
@@ -66,8 +66,8 @@ $ lein uberjar && \
   fi
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.6.jar
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.0.6-standalone.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.0.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.0-standalone.jar
 ```
 
 Or **build** the microservice using **GNU Make** (optional, but for convenience &mdash; it covers the same **Leiningen** build workflow under the hood):
@@ -93,14 +93,14 @@ $ lein run; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `uberjar` Leiningen task or GNU Make's `all` target:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.0.6.jar; echo $?
+$ java -jar target/uberjar/customers-api-lite-0.1.0.jar; echo $?
 ...
 ```
 
 To run the microservice as a *true* daemon, i.e. in the background, redirecting all the console output to `/dev/null`, the following form of invocation of its executable JAR bundle can be used:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.0.6.jar > /dev/null 2>&1 &
+$ java -jar target/uberjar/customers-api-lite-0.1.0.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 
@@ -111,7 +111,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.0.6.jar > /dev/null 2>&1
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.1.0.jar > /dev/null 2>&1
 ```
 
 ## Consuming

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype
@@ -10,7 +10,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject customers-api-lite "0.0.6"
+(defproject customers-api-lite "0.1.0"
     :description     "Customers API Lite microservice prototype."
     :url             "https://github.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit"
     :license {

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/core.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -55,11 +55,23 @@
     ; Getting the port number used to run the http-kit web server.
     (let [server-port (-get-server-port settings)]
 
-    ; Starting up the http-kit web server.
-    (let [server (run-server -req-handler {
-        :port                 server-port
-        :legacy-return-value? false
-    })]
+    ; Trying to start up the http-kit web server.
+    (let [server (try
+        (run-server -req-handler {
+            :port                 server-port
+            :legacy-return-value? false
+        })
+    (catch Exception e
+        (if (and (instance? java.net.BindException e)
+            (= (ex-message e) (MSG-ADDR-ALREADY-IN-USE)))
+
+            (l/error (str (ERR-CANNOT-START-SERVER) (ERR-ADDR-ALREADY-IN-USE)))
+            (l/error (str (ERR-CANNOT-START-SERVER) (ERR-SERV-UNKNOWN-REASON)))
+        )
+
+        (-cleanup)
+        (System/exit (EXIT-FAILURE))
+    ))]
 
     (if (and (instance? org.httpkit.server.HttpServer server)
         (= (server-status server) :running)) (do
@@ -75,6 +87,9 @@
     ;     public void run() {...}
     ; });
     (.addShutdownHook (Runtime/getRuntime) (Thread. #(
+        (l/info  (MSG-SERVER-STOPPED))
+        (.info@s (MSG-SERVER-STOPPED))
+
         (-cleanup)
         (server-stop! server)
     ))))))

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/helper.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -16,8 +16,10 @@
               [clojure.edn           :as edn]))
 
 ; Helper constants.
-(defmacro O-BRACKET [] "[")
-(defmacro C-BRACKET [] "]")
+(defmacro EXIT-FAILURE []   1) ;    Failing exit status.
+(defmacro EXIT-SUCCESS []   0) ; Successful exit status.
+(defmacro O-BRACKET    [] "[")
+(defmacro C-BRACKET    [] "]")
 
 ; Common notification messages.
 (defmacro MSG-SERVER-STARTED [] "Server started on port ")
@@ -27,6 +29,13 @@
 (defmacro ERR-PORT-VALID-MUST-BE-POSITIVE-INT [] (str
     "Valid server port must be a positive integer value, in the range "
     "1024 .. 49151. The default value of 8080 will be used instead."))
+(defmacro ERR-CANNOT-START-SERVER []
+    "FATAL: Cannot start server ")
+(defmacro ERR-ADDR-ALREADY-IN-USE []
+    "due to address requested already in use. Quitting...")
+(defmacro ERR-SERV-UNKNOWN-REASON []
+    "for an unknown reason. Quitting...")
+(defmacro MSG-ADDR-ALREADY-IN-USE [] "Address already in use")
 
 (defmacro SETTINGS "The filename of the daemon settings
     (in edn (Extensible Data Notation) format)." [] "settings.conf")
@@ -68,9 +77,6 @@
 
 ; Helper function. Makes final cleanups, closes streams, etc.
 (defn -cleanup []
-    (l/info  (MSG-SERVER-STOPPED))
-    (.info@s (MSG-SERVER-STOPPED))
-
     ; Closing the system logger.
     ; Calling <syslog.h> closelog();
     (.shutdown@s)

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -1,7 +1,7 @@
 ;
 ; src/resources/settings.conf
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.0.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- Trying to start up the **http-kit** web server inside a `(try)` block, specifically catching and handling exceptions (if any) and complain accordingly.
- Adding constants: _daemon exit statuses_ (POSIX-related) and _common error messages_ regarding complaints when the server cannot be started due to some fatal errors.
- Bringing out server termination messages from the `(-cleanup/0)` helper function to a shutdown hook.
- Bumping version number to **0.1.0**.