### PR TITLE
Introduce the controller namespace of the daemon. Connect to the database.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -29,7 +29,7 @@ $(SRV):
 $(JAR):
 	$(LEIN) $(UBERJAR) && \
 	DAEMON_NAME="customers-api-lite"; \
-	DMN_VERSION="0.1.0"; \
+	DMN_VERSION="0.1.5"; \
 	SIMPLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}.jar"; \
 	BUNDLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}-standalone.jar"; \
 	$(RM) $${SIMPLE_JAR} && $(MV) $${BUNDLE_JAR} $${SIMPLE_JAR} && \

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $ sudo pacman -Syu jdk21-openjdk leiningen make docker
 $ lein clean
 $
 $ lein compile :all
+Compiling customers.api-lite.controller
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
 $
@@ -64,6 +65,7 @@ $ lein uberjar && \
   if [ -f ${DB_DIR}/${DAEMON_NAME}.db.xz ]; then \
      unxz ${DB_DIR}/${DAEMON_NAME}.db.xz; \
   fi
+Compiling customers.api-lite.controller
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
 Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.0.jar

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $
 $ lein uberjar && \
   UBERJAR_DIR="target/uberjar"; \
   DAEMON_NAME="customers-api-lite"; \
-  DMN_VERSION="0.1.0"; \
+  DMN_VERSION="0.1.5"; \
   SIMPLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}.jar"; \
   BUNDLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}-standalone.jar"; \
   rm ${SIMPLE_JAR} && mv ${BUNDLE_JAR} ${SIMPLE_JAR} && \
@@ -68,8 +68,8 @@ $ lein uberjar && \
 Compiling customers.api-lite.controller
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.0.jar
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.0-standalone.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.5.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.5-standalone.jar
 ```
 
 Or **build** the microservice using **GNU Make** (optional, but for convenience &mdash; it covers the same **Leiningen** build workflow under the hood):
@@ -95,14 +95,14 @@ $ lein run; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `uberjar` Leiningen task or GNU Make's `all` target:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.1.0.jar; echo $?
+$ java -jar target/uberjar/customers-api-lite-0.1.5.jar; echo $?
 ...
 ```
 
 To run the microservice as a *true* daemon, i.e. in the background, redirecting all the console output to `/dev/null`, the following form of invocation of its executable JAR bundle can be used:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.1.0.jar > /dev/null 2>&1 &
+$ java -jar target/uberjar/customers-api-lite-0.1.5.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 
@@ -113,7 +113,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.1.0.jar > /dev/null 2>&1
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.1.5.jar > /dev/null 2>&1
 ```
 
 ## Consuming

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/project.clj
+++ b/project.clj
@@ -18,12 +18,14 @@
         :url  "https://raw.githubusercontent.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit/main/LICENSE"
     }
     :dependencies [
-        [org.clojure/clojure       "1.12.3"]
-        [org.clojure/tools.logging "1.3.0" ]
-        [org.slf4j/slf4j-reload4j  "2.0.17"]
-        [org.graylog2/syslog4j     "0.9.61"]
-        [net.java.dev.jna/jna      "5.18.0"]
-        [http-kit                  "2.8.1" ]
+        [org.clojure/clojure               "1.12.3"  ]
+        [org.clojure/tools.logging         "1.3.0"   ]
+        [org.slf4j/slf4j-reload4j          "2.0.17"  ]
+        [org.graylog2/syslog4j             "0.9.61"  ]
+        [net.java.dev.jna/jna              "5.18.0"  ]
+        [com.github.seancorfield/next.jdbc "1.3.1070"]
+        [org.xerial/sqlite-jdbc            "3.50.3.0"]
+        [http-kit                          "2.8.1"   ]
     ]
     :main ^:skip-aot customers.api-lite.core
     :target-path     "target/%s"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype
@@ -10,7 +10,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject customers-api-lite "0.1.0"
+(defproject customers-api-lite "0.1.5"
     :description     "Customers API Lite microservice prototype."
     :url             "https://github.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit"
     :license {

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -27,6 +27,8 @@
     (-dbg (str (O-BRACKET) (s/upper-case (s/replace method (COLON) (str)))
                (C-BRACKET))))
 
+    (-dbg (str (O-BRACKET) @cnx (C-BRACKET)))
+
     {:headers {
         (CONT-TYPE) (MIME-TYPE)
     }}

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -11,7 +11,8 @@
 ;
 
 (ns customers.api-lite.controller "The controller namespace of the daemon."
-    (:use [customers.api-lite.helper]))
+    (:use     [customers.api-lite.helper])
+    (:require [clojure.string :as s     ]))
 
 (defn req-handler
     "The request handler callback. Gets called on each incoming HTTP request.
@@ -20,7 +21,15 @@
         req: A hash map representing the incoming HTTP request object."
     {:added "0.1.0"} [req]
 
-    (-dbg (str (O-BRACKET) req (C-BRACKET)))
+;   (-dbg (str (O-BRACKET) req (C-BRACKET)))
+
+    (let [method (get req :request-method)]
+    (-dbg (str (O-BRACKET) (s/upper-case (s/replace method (COLON) (str)))
+               (C-BRACKET))))
+
+    {:headers {
+        (CONT-TYPE) (MIME-TYPE)
+    }}
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/controller.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -1,0 +1,26 @@
+;
+; src/customers/api_lite/controller.clj
+; =============================================================================
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+; =============================================================================
+; A daemon written in Clojure, designed and intended to be run
+; as a microservice, implementing a special Customers API prototype
+; with a smart yet simplified data scheme.
+; =============================================================================
+; (See the LICENSE file at the top of the source tree.)
+;
+
+(ns customers.api-lite.controller "The controller namespace of the daemon."
+    (:use [customers.api-lite.helper]))
+
+(defn req-handler
+    "The request handler callback. Gets called on each incoming HTTP request.
+
+    Args:
+        req: A hash map representing the incoming HTTP request object."
+    {:added "0.1.0"} [req]
+
+    (-dbg (str (O-BRACKET) req (C-BRACKET)))
+)
+
+; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -14,7 +14,8 @@
     (:import  (org.graylog2.syslog4j.impl.unix UnixSyslogConfig)
               (org.graylog2.syslog4j.impl.unix UnixSyslog      )
               (org.graylog2.syslog4j           SyslogIF        ))
-    (:use     [customers.api-lite.helper  ])
+    (:use     [customers.api-lite.helper    ]
+              [customers.api-lite.controller])
     (:require [clojure.tools.logging :as l]
               [org.httpkit.server :refer  [
                   run-server
@@ -22,15 +23,11 @@
                   server-stop!
               ]]))
 
-(defn- -req-handler [req]
-    (-dbg (str (O-BRACKET) req (C-BRACKET)))
-)
-
 (defn -main
     "The microservice entry point.
 
     Args:
-        args: A vector of command-line arguments."
+        args: A list of command-line arguments."
     {:added "0.0.1"} [& args]
 
     ; Opening the system logger.
@@ -57,7 +54,7 @@
 
     ; Trying to start up the http-kit web server.
     (let [server (try
-        (run-server -req-handler {
+        (run-server req-handler {
             :port                 server-port
             :legacy-return-value? false
         })

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -16,8 +16,9 @@
               (org.graylog2.syslog4j           SyslogIF        ))
     (:use     [customers.api-lite.helper    ]
               [customers.api-lite.controller])
-    (:require [clojure.tools.logging :as l]
-              [org.httpkit.server :refer  [
+    (:require [clojure.tools.logging :as l  ]
+              [next.jdbc             :as db ]
+              [org.httpkit.server    :refer [
                   run-server
                   server-status
                   server-stop!
@@ -43,11 +44,14 @@
     (reset! dbg (get settings :logger.debug.enabled))
 
     (let [daemon-name (get settings :daemon.name)]
-
     (-dbg (str (O-BRACKET) daemon-name (C-BRACKET))))
 
-    ; Getting the SQLite database path.
-    (let [database-path (get settings :sqlite.database.path)])
+    ; Getting the SQLite database JDBC URL.
+    (let [datasource-url (get settings :sqlite.datasource.url)]
+
+    ; Connecting to the database.
+    (reset! cnx (db/get-connection (db/get-datasource datasource-url)))
+    (-dbg (str (O-BRACKET) @cnx (C-BRACKET))))
 
     ; Getting the port number used to run the http-kit web server.
     (let [server-port (-get-server-port settings)]

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/core.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -52,6 +52,7 @@
 ; Globals.
 (def s   "The Unix system logger."    (atom {}))
 (def dbg "The debug logging enabler." (atom {}))
+(def cnx "The database connection."   (atom {}))
 
 ; Helper function. Used to get the daemon settings.
 (defn -get-settings [] (edn/read-string (slurp (io/resource (SETTINGS)))))
@@ -82,6 +83,8 @@
 
 ; Helper function. Makes final cleanups, closes streams, etc.
 (defn -cleanup []
+    (.close@cnx)
+
     ; Closing the system logger.
     ; Calling <syslog.h> closelog();
     (.shutdown@s)

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -18,6 +18,7 @@
 ; Helper constants.
 (defmacro EXIT-FAILURE []   1) ;    Failing exit status.
 (defmacro EXIT-SUCCESS []   0) ; Successful exit status.
+(defmacro COLON        [] ":")
 (defmacro O-BRACKET    [] "[")
 (defmacro C-BRACKET    [] "]")
 
@@ -43,6 +44,10 @@
 (defmacro MIN-PORT "The minimum port number allowed." [] 1024 )
 (defmacro MAX-PORT "The maximum port number allowed." [] 49151)
 (defmacro DEF-PORT "The default server port number."  [] 8080 )
+
+; HTTP response-related constants.
+(defmacro CONT-TYPE [] "content-type"    )
+(defmacro MIME-TYPE [] "application/json")
 
 ; Globals.
 (def s   "The Unix system logger."    (atom {}))

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/helper.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -17,6 +17,6 @@
 ; Uncomment this setting to enable debug logging.
 ;:logger.debug.enabled true
 
-:sqlite.database.path "./data/db/customers-api-lite.db"
+:sqlite.datasource.url "jdbc:sqlite:data/db/customers-api-lite.db"
 
 }; vim:set nu et ts=4 sw=4:

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -1,7 +1,7 @@
 ;
 ; src/resources/settings.conf
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.0
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- Introducing the **controller namespace** of the daemon.
- Adding HTTP response-related (and helper) constants.
- Responding with the specified `content-type` header and printing out the request method used.
- Adding a dependency: `next.jdbc` (**A modern low-level Clojure wrapper for JDBC-based access to databases**) and `sqlite-jdbc` (**SQLite JDBC**) to utilize JDBC driver and library for SQLite database: as a runtime dependency to **next.jdbc**.
- Utilizing the _complete datasource JDBC URL_ instead of just _database filesystem path_.
- Declaring a new global var &mdash; the **database connection** object; closing the connection at final cleanups.
- Establishing JDBC connection to the SQLite database.
- Bumping version number to **0.1.5**.