### PR TITLE
Serve routes through the Compojure routing library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -29,7 +29,7 @@ $(SRV):
 $(JAR):
 	$(LEIN) $(UBERJAR) && \
 	DAEMON_NAME="customers-api-lite"; \
-	DMN_VERSION="0.1.5"; \
+	DMN_VERSION="0.1.6"; \
 	SIMPLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}.jar"; \
 	BUNDLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}-standalone.jar"; \
 	$(RM) $${SIMPLE_JAR} && $(MV) $${BUNDLE_JAR} $${SIMPLE_JAR} && \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $
 $ lein uberjar && \
   UBERJAR_DIR="target/uberjar"; \
   DAEMON_NAME="customers-api-lite"; \
-  DMN_VERSION="0.1.5"; \
+  DMN_VERSION="0.1.6"; \
   SIMPLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}.jar"; \
   BUNDLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}-standalone.jar"; \
   rm ${SIMPLE_JAR} && mv ${BUNDLE_JAR} ${SIMPLE_JAR} && \
@@ -68,8 +68,8 @@ $ lein uberjar && \
 Compiling customers.api-lite.controller
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.5.jar
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.5-standalone.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.6.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.6-standalone.jar
 ```
 
 Or **build** the microservice using **GNU Make** (optional, but for convenience &mdash; it covers the same **Leiningen** build workflow under the hood):
@@ -95,14 +95,14 @@ $ lein run; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `uberjar` Leiningen task or GNU Make's `all` target:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.1.5.jar; echo $?
+$ java -jar target/uberjar/customers-api-lite-0.1.6.jar; echo $?
 ...
 ```
 
 To run the microservice as a *true* daemon, i.e. in the background, redirecting all the console output to `/dev/null`, the following form of invocation of its executable JAR bundle can be used:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.1.5.jar > /dev/null 2>&1 &
+$ java -jar target/uberjar/customers-api-lite-0.1.6.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 
@@ -113,7 +113,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.1.5.jar > /dev/null 2>&1
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.1.6.jar > /dev/null 2>&1
 ```
 
 ## Consuming

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,7 @@
         [com.github.seancorfield/next.jdbc "1.3.1070"]
         [org.xerial/sqlite-jdbc            "3.50.3.0"]
         [http-kit                          "2.8.1"   ]
+        [compojure                         "1.7.2"   ]
     ]
     :main ^:skip-aot customers.api-lite.core
     :target-path     "target/%s"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype
@@ -10,7 +10,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject customers-api-lite "0.1.5"
+(defproject customers-api-lite "0.1.6"
     :description     "Customers API Lite microservice prototype."
     :url             "https://github.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit"
     :license {

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -15,6 +15,7 @@
     (:require [clojure.string :as s     ]
               [compojure.core :refer    [
                   defroutes
+                  context
                   GET
               ]]))
 
@@ -92,13 +93,19 @@
     Gets called on each incoming HTTP request."
     {:added "0.1.5"}
 
-    (GET (SLASH) [] root-req-handler)
+    (GET (SLASH) [] root-req-handler) ; <== GET /
 
-    (GET (str (SLASH) (REST-VERSION)
-              (SLASH) (REST-PREFIX)) [] list-customers)
-    (GET (str (SLASH) (REST-VERSION)
-              (SLASH) (REST-PREFIX)
-              (SLASH) (COLON) (REST-CUST-ID)) [] get-customer)
+    ; /v1/customers
+    (context (str (SLASH) (REST-VERSION) (SLASH) (REST-PREFIX)) []
+;       (PUT      (SLASH)                           []  add-customer )
+;       (PUT (str (SLASH)         (REST-CONTACTS))  []  add-contact  )
+        (GET      (SLASH)                           [] list-customers)
+        (GET (str (SLASH) (COLON) (REST-CUST-ID))   []  get-customer ))
+;       (GET (str (SLASH) (COLON) (REST-CUST-ID)
+;                 (SLASH)         (REST-CONTACTS))  [] list-contacts )
+;       (GET (str (SLASH) (COLON) (REST-CUST-ID)
+;                 (SLASH)         (REST-CONTACTS)
+;                 (SLASH) (COLON) (REST-CONT-TYPE)) [] list-contacts-by-type))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -39,13 +39,66 @@
     }}
 )
 
+; REST API endpoints ----------------------------------------------------------
+
+(defn list-customers
+    "The `GET /v1/customers` endpoint.
+    Retrieves from the database and lists all customer profiles.
+
+    Args:
+        req: A hash map representing the incoming HTTP request object.
+
+    Returns:
+        HTTP status code `200 OK` and the response body in JSON representation,
+        containing a list of all customer profiles.
+        May return client or server error depending on incoming request."
+    {:added "0.1.5"} [req]
+
+    (let [method- (get req :request-method)]
+    (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
+    (-dbg (str (O-BRACKET) method (C-BRACKET)))))
+
+    {:headers {
+        (CONT-TYPE) (MIME-TYPE)
+    }}
+)
+
+(defn get-customer
+    "The `GET /v1/customers/{customer_id}` endpoint.
+    Retrieves profile details for a given customer from the database.
+
+    Args:
+        req: A hash map representing the incoming HTTP request object.
+
+    Returns:
+        A specific HTTP status code with profile details for a given customer
+        (in the response body in JSON representation).
+        May return client or server error depending on incoming request."
+    {:added "0.1.5"} [req]
+
+    (let [method- (get req :request-method)]
+    (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
+    (-dbg (str (O-BRACKET) method (C-BRACKET)))))
+
+    {:headers {
+        (CONT-TYPE) (MIME-TYPE)
+    }}
+)
+
+; -----------------------------------------------------------------------------
+
 (defroutes api-lite-routes
     "The compound request handler callback (Compojure middleware).
     Gets called on each incoming HTTP request."
-
     {:added "0.1.5"}
 
     (GET (SLASH) [] root-req-handler)
+
+    (GET (str (SLASH) (REST-VERSION)
+              (SLASH) (REST-PREFIX)) [] list-customers)
+    (GET (str (SLASH) (REST-VERSION)
+              (SLASH) (REST-PREFIX)
+              (SLASH) (COLON) (REST-CUST-ID)) [] get-customer)
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -12,10 +12,15 @@
 
 (ns customers.api-lite.controller "The controller namespace of the daemon."
     (:use     [customers.api-lite.helper])
-    (:require [clojure.string :as s     ]))
+    (:require [clojure.string :as s     ]
+              [compojure.core :refer    [
+                  defroutes
+                  GET
+              ]]))
 
-(defn req-handler
-    "The request handler callback. Gets called on each incoming HTTP request.
+(defn root-req-handler
+    "The root request handler callback.
+    Gets called on each `/` incoming HTTP request.
 
     Args:
         req: A hash map representing the incoming HTTP request object."
@@ -32,6 +37,15 @@
     {:headers {
         (CONT-TYPE) (MIME-TYPE)
     }}
+)
+
+(defroutes api-lite-routes
+    "The compound request handler callback (Compojure middleware).
+    Gets called on each incoming HTTP request."
+
+    {:added "0.1.5"}
+
+    (GET (SLASH) [] root-req-handler)
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/controller.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/core.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -58,7 +58,7 @@
 
     ; Trying to start up the http-kit web server.
     (let [server (try
-        (run-server req-handler {
+        (run-server api-lite-routes {
             :port                 server-port
             :legacy-return-value? false
         })

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -19,6 +19,7 @@
 (defmacro EXIT-FAILURE []   1) ;    Failing exit status.
 (defmacro EXIT-SUCCESS []   0) ; Successful exit status.
 (defmacro COLON        [] ":")
+(defmacro SLASH        [] "/")
 (defmacro O-BRACKET    [] "[")
 (defmacro C-BRACKET    [] "]")
 

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/helper.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -46,6 +46,11 @@
 (defmacro MAX-PORT "The maximum port number allowed." [] 49151)
 (defmacro DEF-PORT "The default server port number."  [] 8080 )
 
+; REST URI path-related constants.
+(defmacro REST-VERSION [] "v1"         )
+(defmacro REST-PREFIX  [] "customers"  )
+(defmacro REST-CUST-ID [] "customer_id")
+
 ; HTTP response-related constants.
 (defmacro CONT-TYPE [] "content-type"    )
 (defmacro MIME-TYPE [] "application/json")

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -1,7 +1,7 @@
 ;
 ; src/resources/settings.conf
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.5
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- Adding a dependency: `compojure` (**A concise routing library for Ring/Clojure**).
- Adding REST URI path-related constants.
- Defining first two `GET` REST API endpoints-callbacks, actually endpoint stubs: they currently return nothing except a bare status code.
- Serving routes through the **Compojure** middleware.
- Bumping version number to **0.1.6**.