### PR TITLE
Define two `PUT` and two remaining `GET` REST API endpoint stubs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -29,7 +29,7 @@ $(SRV):
 $(JAR):
 	$(LEIN) $(UBERJAR) && \
 	DAEMON_NAME="customers-api-lite"; \
-	DMN_VERSION="0.1.6"; \
+	DMN_VERSION="0.1.7"; \
 	SIMPLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}.jar"; \
 	BUNDLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}-standalone.jar"; \
 	$(RM) $${SIMPLE_JAR} && $(MV) $${BUNDLE_JAR} $${SIMPLE_JAR} && \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $
 $ lein uberjar && \
   UBERJAR_DIR="target/uberjar"; \
   DAEMON_NAME="customers-api-lite"; \
-  DMN_VERSION="0.1.6"; \
+  DMN_VERSION="0.1.7"; \
   SIMPLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}.jar"; \
   BUNDLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}-standalone.jar"; \
   rm ${SIMPLE_JAR} && mv ${BUNDLE_JAR} ${SIMPLE_JAR} && \
@@ -68,8 +68,8 @@ $ lein uberjar && \
 Compiling customers.api-lite.controller
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.6.jar
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.6-standalone.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.7.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.7-standalone.jar
 ```
 
 Or **build** the microservice using **GNU Make** (optional, but for convenience &mdash; it covers the same **Leiningen** build workflow under the hood):
@@ -95,14 +95,14 @@ $ lein run; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `uberjar` Leiningen task or GNU Make's `all` target:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.1.6.jar; echo $?
+$ java -jar target/uberjar/customers-api-lite-0.1.7.jar; echo $?
 ...
 ```
 
 To run the microservice as a *true* daemon, i.e. in the background, redirecting all the console output to `/dev/null`, the following form of invocation of its executable JAR bundle can be used:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.1.6.jar > /dev/null 2>&1 &
+$ java -jar target/uberjar/customers-api-lite-0.1.7.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 
@@ -113,7 +113,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.1.6.jar > /dev/null 2>&1
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.1.7.jar > /dev/null 2>&1
 ```
 
 ## Consuming

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype
@@ -10,7 +10,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject customers-api-lite "0.1.6"
+(defproject customers-api-lite "0.1.7"
     :description     "Customers API Lite microservice prototype."
     :url             "https://github.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit"
     :license {

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -33,6 +33,7 @@
 
 (defn add-customer
     "The `PUT /v1/customers` endpoint.
+
     Creates a new customer (puts customer data to the database).
 
     The request body is defined exactly in the form
@@ -67,6 +68,7 @@
 
 (defn add-contact
     "The `PUT /v1/customers/contacts` endpoint.
+
     Creates a new contact for a given customer (puts a contact
     regarding a given customer to the database).
 
@@ -106,6 +108,7 @@
 
 (defn list-customers
     "The `GET /v1/customers` endpoint.
+
     Retrieves from the database and lists all customer profiles.
 
     Args:
@@ -126,6 +129,7 @@
 
 (defn get-customer
     "The `GET /v1/customers/{customer_id}` endpoint.
+
     Retrieves profile details for a given customer from the database.
 
     Args:
@@ -144,10 +148,55 @@
     }}
 )
 
+(defn list-contacts
+    "The `GET /v1/customers/{customer_id}/contacts` endpoint.
+
+    Retrieves from the database and lists all contacts
+    associated with a given customer.
+
+    Args:
+        req: A hash map representing the incoming HTTP request object.
+
+    Returns:
+        HTTP status code `200 OK` and the response body in JSON representation,
+        containing a list of all contacts associated with a given customer.
+        May return client or server error depending on incoming request."
+    {:added "0.1.6"} [req]
+
+    (-method req)
+
+    {:headers {
+        (CONT-TYPE) (MIME-TYPE)
+    }}
+)
+
+(defn list-contacts-by-type
+    "The `GET /v1/customers/{customer_id}/contacts/{contact_type}` endpoint.
+
+    Retrieves from the database and lists all contacts of a given type
+    associated with a given customer.
+
+    Args:
+        req: A hash map representing the incoming HTTP request object.
+
+    Returns:
+        HTTP status code `200 OK` and the response body in JSON representation,
+        containing a list of all contacts of a given type
+        associated with a given customer.
+        May return client or server error depending on incoming request."
+    {:added "0.1.6"} [req]
+
+    (-method req)
+
+    {:headers {
+        (CONT-TYPE) (MIME-TYPE)
+    }}
+)
+
 ; -----------------------------------------------------------------------------
 
 (defroutes api-lite-routes
-    "The compound request handler callback (Compojure middleware).
+    "The compound request handler callback (Compojure routing facility).
     Gets called on each incoming HTTP request."
     {:added "0.1.5"}
 
@@ -156,12 +205,12 @@
         (PUT      (SLASH)                           []  add-customer )
         (PUT (str (SLASH)         (REST-CONTACTS))  []  add-contact  )
         (GET      (SLASH)                           [] list-customers)
-        (GET (str (SLASH) (COLON) (REST-CUST-ID))   []  get-customer ))
-;       (GET (str (SLASH) (COLON) (REST-CUST-ID)
-;                 (SLASH)         (REST-CONTACTS))  [] list-contacts )
-;       (GET (str (SLASH) (COLON) (REST-CUST-ID)
-;                 (SLASH)         (REST-CONTACTS)
-;                 (SLASH) (COLON) (REST-CONT-TYPE)) [] list-contacts-by-type))
+        (GET (str (SLASH) (COLON) (REST-CUST-ID))   []  get-customer )
+        (GET (str (SLASH) (COLON) (REST-CUST-ID)
+                  (SLASH)         (REST-CONTACTS))  [] list-contacts )
+        (GET (str (SLASH) (COLON) (REST-CUST-ID)
+                  (SLASH)         (REST-CONTACTS)
+                  (SLASH) (COLON) (REST-CONT-TYPE)) [] list-contacts-by-type))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -20,29 +20,6 @@
                   GET
               ]]))
 
-; Request filters -------------------------------------------------------------
-
-(defn any-req-filter
-    "The root request handler callback.
-    Gets called on each `/` incoming HTTP request.
-
-    Args:
-        req: A hash map representing the incoming HTTP request object."
-    {:added "0.1.0"} [req]
-
-;   (-dbg (str (O-BRACKET) req (C-BRACKET)))
-
-    (let [method- (get req :request-method)]
-    (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
-    (-dbg (str (O-BRACKET) method (C-BRACKET)))))
-
-;   (-dbg (str (O-BRACKET) @cnx (C-BRACKET)))
-
-    {:headers {
-        (CONT-TYPE) (MIME-TYPE)
-    }}
-)
-
 ; REST API endpoints ----------------------------------------------------------
 
 (defn list-customers
@@ -58,13 +35,15 @@
         May return client or server error depending on incoming request."
     {:added "0.1.5"} [req]
 
-    (let [method- (get req :request-method)]
-    (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
-    (-dbg (str (O-BRACKET) method (C-BRACKET)))))
+;   (let [method- (get req :request-method)]
+;   (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
+;   (-dbg (str (O-BRACKET) method (C-BRACKET)))))
 
-    {:headers {
-        (CONT-TYPE) (MIME-TYPE)
-    }}
+    (-dbg (str (O-BRACKET) "list-customers" (C-BRACKET)))
+
+;   {:headers {
+;       (CONT-TYPE) (MIME-TYPE)
+;   }}
 )
 
 (defn get-customer
@@ -80,9 +59,38 @@
         May return client or server error depending on incoming request."
     {:added "0.1.5"} [req]
 
+;   (let [method- (get req :request-method)]
+;   (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
+;   (-dbg (str (O-BRACKET) method (C-BRACKET)))))
+
+    (-dbg (str (O-BRACKET) "get-customer" (C-BRACKET)))
+
+;   {:headers {
+;       (CONT-TYPE) (MIME-TYPE)
+;   }}
+)
+
+; Request (post-)filters ------------------------------------------------------
+
+(defn any-req-filter
+    "The so-called request post-filter/handler callback.
+    Gets called on each `/*` incoming HTTP request.
+
+    Args:
+        req: A hash map representing the incoming HTTP request object.
+
+    Returns:
+        A specific HTTP status code + the JSON `content-type` response header.
+        May return client or server error depending on incoming request."
+    {:added "0.1.0"} [req]
+
+;   (-dbg (str (O-BRACKET) req (C-BRACKET)))
+
     (let [method- (get req :request-method)]
     (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
     (-dbg (str (O-BRACKET) method (C-BRACKET)))))
+
+;   (-dbg (str (O-BRACKET) @cnx (C-BRACKET)))
 
     {:headers {
         (CONT-TYPE) (MIME-TYPE)
@@ -96,9 +104,6 @@
     Gets called on each incoming HTTP request."
     {:added "0.1.5"}
 
-    ; /
-    (ANY (SLASH) [] any-req-filter)
-
     ; /v1/customers
     (context (str (SLASH) (REST-VERSION) (SLASH) (REST-PREFIX)) []
 ;       (PUT      (SLASH)                           []  add-customer )
@@ -110,6 +115,9 @@
 ;       (GET (str (SLASH) (COLON) (REST-CUST-ID)
 ;                 (SLASH)         (REST-CONTACTS)
 ;                 (SLASH) (COLON) (REST-CONT-TYPE)) [] list-contacts-by-type))
+
+    ; /*
+    (ANY (ANY-) [] any-req-filter)
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/controller.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -16,10 +16,13 @@
               [compojure.core :refer    [
                   defroutes
                   context
+                  ANY
                   GET
               ]]))
 
-(defn root-req-handler
+; Request filters -------------------------------------------------------------
+
+(defn any-req-filter
     "The root request handler callback.
     Gets called on each `/` incoming HTTP request.
 
@@ -93,7 +96,8 @@
     Gets called on each incoming HTTP request."
     {:added "0.1.5"}
 
-    (GET (SLASH) [] root-req-handler) ; <== GET /
+    ; /
+    (ANY (SLASH) [] any-req-filter)
 
     ; /v1/customers
     (context (str (SLASH) (REST-VERSION) (SLASH) (REST-PREFIX)) []

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -12,12 +12,15 @@
 
 (ns customers.api-lite.controller "The controller namespace of the daemon."
     (:use     [customers.api-lite.helper])
-    (:require [clojure.string :as s     ]
-              [compojure.core :refer    [
+    (:require [clojure.string  :as s    ]
+              [compojure.core  :refer   [
                   defroutes
                   context
                   PUT
                   GET
+              ]]
+              [compojure.route :refer   [
+                  not-found
               ]]))
 
 ; Helper function. Used to expose a request method on incoming HTTP requests.
@@ -197,7 +200,21 @@
 
 (defroutes api-lite-routes
     "The compound request handler callback (Compojure routing facility).
-    Gets called on each incoming HTTP request."
+    Gets called on each incoming HTTP request.
+
+    Allowed and properly handled routes are the following ones:
+
+    ```
+    PUT /v1/customers
+    PUT /v1/customers/contacts
+    GET /v1/customers
+    GET /v1/customers/:customer_id
+    GET /v1/customers/:customer_id/contacts
+    GET /v1/customers/:customer_id/contacts/:contact_type
+    ```
+
+    Accessing routes other than the above will likely end up in getting
+    `404 Not Found` or `405 Method Not Allowed` responses."
     {:added "0.1.5"}
 
     ; /v1/customers
@@ -211,6 +228,16 @@
         (GET (str (SLASH) (COLON) (REST-CUST-ID)
                   (SLASH)         (REST-CONTACTS)
                   (SLASH) (COLON) (REST-CONT-TYPE)) [] list-contacts-by-type))
+
+    ; For any other route Compojure will automatically respond
+    ; with the HTTP 404 Not Found status code.
+    ; FIXME: Replace the hand-made JSON below with a production-grade,
+    ;        lib-based one by incorporating any JSON lib for that.
+    (not-found {:headers {
+        (CONT-TYPE) (MIME-TYPE)
+    } :body
+        (str "{\"" (ERR-KEY) "\"" (COLON) "\"" (ERR-REQ-NOT-FOUND-1) "\"}")
+    })
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -20,6 +20,15 @@
                   GET
               ]]))
 
+; Helper function. Used to expose a request method on incoming HTTP requests.
+(defn -method [req]
+;   (-dbg (str (O-BRACKET) req (C-BRACKET)))
+
+    (let [method- (get req :request-method)]
+    (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
+    (-dbg (str (O-BRACKET) method (C-BRACKET)))))
+)
+
 ; REST API endpoints ----------------------------------------------------------
 
 (defn list-customers
@@ -35,15 +44,11 @@
         May return client or server error depending on incoming request."
     {:added "0.1.5"} [req]
 
-;   (let [method- (get req :request-method)]
-;   (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
-;   (-dbg (str (O-BRACKET) method (C-BRACKET)))))
+    (-method req)
 
-    (-dbg (str (O-BRACKET) "list-customers" (C-BRACKET)))
-
-;   {:headers {
-;       (CONT-TYPE) (MIME-TYPE)
-;   }}
+    {:headers {
+        (CONT-TYPE) (MIME-TYPE)
+    }}
 )
 
 (defn get-customer
@@ -59,38 +64,7 @@
         May return client or server error depending on incoming request."
     {:added "0.1.5"} [req]
 
-;   (let [method- (get req :request-method)]
-;   (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
-;   (-dbg (str (O-BRACKET) method (C-BRACKET)))))
-
-    (-dbg (str (O-BRACKET) "get-customer" (C-BRACKET)))
-
-;   {:headers {
-;       (CONT-TYPE) (MIME-TYPE)
-;   }}
-)
-
-; Request (post-)filters ------------------------------------------------------
-
-(defn any-req-filter
-    "The so-called request post-filter/handler callback.
-    Gets called on each `/*` incoming HTTP request.
-
-    Args:
-        req: A hash map representing the incoming HTTP request object.
-
-    Returns:
-        A specific HTTP status code + the JSON `content-type` response header.
-        May return client or server error depending on incoming request."
-    {:added "0.1.0"} [req]
-
-;   (-dbg (str (O-BRACKET) req (C-BRACKET)))
-
-    (let [method- (get req :request-method)]
-    (let [method  (s/upper-case (s/replace method- (COLON) (str)))]
-    (-dbg (str (O-BRACKET) method (C-BRACKET)))))
-
-;   (-dbg (str (O-BRACKET) @cnx (C-BRACKET)))
+    (-method req)
 
     {:headers {
         (CONT-TYPE) (MIME-TYPE)
@@ -115,9 +89,6 @@
 ;       (GET (str (SLASH) (COLON) (REST-CUST-ID)
 ;                 (SLASH)         (REST-CONTACTS)
 ;                 (SLASH) (COLON) (REST-CONT-TYPE)) [] list-contacts-by-type))
-
-    ; /*
-    (ANY (ANY-) [] any-req-filter)
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -16,7 +16,6 @@
               [compojure.core :refer    [
                   defroutes
                   context
-                  ANY
                   GET
               ]]))
 

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -16,6 +16,7 @@
               [compojure.core :refer    [
                   defroutes
                   context
+                  PUT
                   GET
               ]]))
 
@@ -29,6 +30,79 @@
 )
 
 ; REST API endpoints ----------------------------------------------------------
+
+(defn add-customer
+    "The `PUT /v1/customers` endpoint.
+    Creates a new customer (puts customer data to the database).
+
+    The request body is defined exactly in the form
+    as `{\"name\":\"{customer_name}\"}`. It should be passed
+    with the accompanied request header `content-type` just like the following:
+
+    ```
+    -H 'content-type: application/json' -d '{\"name\":\"{customer_name}\"}'
+    ```
+
+    `{customer_name}` is a name assigned to a newly created customer.
+
+    Args:
+        req: A hash map representing the incoming HTTP request object.
+
+    Returns:
+        HTTP status code `201 Created`, the `Location` response header
+        (among others), and the response body in JSON representation,
+        containing profile details of a newly created customer.
+        May return client or server error depending on incoming request."
+    {:added "0.1.6"} [req]
+
+    (-method req)
+
+    {:status 201 :headers {
+        (HDR-LOCATION) (str (SLASH) (REST-VERSION)
+                            (SLASH) (REST-PREFIX)
+                            (SLASH) "?")
+        (CONT-TYPE) (MIME-TYPE)
+    }}
+)
+
+(defn add-contact
+    "The `PUT /v1/customers/contacts` endpoint.
+    Creates a new contact for a given customer (puts a contact
+    regarding a given customer to the database).
+
+    The request body is defined exactly in the form
+    as `{\"customer_id\":\"{customer_id}\",\"contact\":\"{customer_contact}\"}`
+    It should be passed with the accompanied request header `content-type`
+    just like the following:
+
+    ```
+    -H 'content-type: application/json' -d '{\"customer_id\":\"{customer_id}\",\"contact\":\"{customer_contact}\"}'
+    ```
+
+    `{customer_id}` is the customer ID used to associate a newly created
+    contact with this customer.
+
+    Args:
+        req: A hash map representing the incoming HTTP request object.
+
+    Returns:
+        HTTP status code `201 Created`, the `Location` response header
+        (among others), and the response body in JSON representation,
+        containing details of a newly created customer contact (phone or email)
+        May return client or server error depending on incoming request."
+    {:added "0.1.6"} [req]
+
+    (-method req)
+
+    {:status 201 :headers {
+        (HDR-LOCATION) (str (SLASH) (REST-VERSION)
+                            (SLASH) (REST-PREFIX)
+                            (SLASH) "?"
+                            (SLASH) (REST-CONTACTS)
+                            (SLASH) "?")
+        (CONT-TYPE) (MIME-TYPE)
+    }}
+)
 
 (defn list-customers
     "The `GET /v1/customers` endpoint.
@@ -79,8 +153,8 @@
 
     ; /v1/customers
     (context (str (SLASH) (REST-VERSION) (SLASH) (REST-PREFIX)) []
-;       (PUT      (SLASH)                           []  add-customer )
-;       (PUT (str (SLASH)         (REST-CONTACTS))  []  add-contact  )
+        (PUT      (SLASH)                           []  add-customer )
+        (PUT (str (SLASH)         (REST-CONTACTS))  []  add-contact  )
         (GET      (SLASH)                           [] list-customers)
         (GET (str (SLASH) (COLON) (REST-CUST-ID))   []  get-customer ))
 ;       (GET (str (SLASH) (COLON) (REST-CUST-ID)

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/core.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -19,7 +19,6 @@
 (defmacro EXIT-FAILURE []   1) ;    Failing exit status.
 (defmacro EXIT-SUCCESS []   0) ; Successful exit status.
 (defmacro COLON        [] ":")
-(defmacro ANY-         [] "*")
 (defmacro SLASH        [] "/")
 (defmacro O-BRACKET    [] "[")
 (defmacro C-BRACKET    [] "]")

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -19,6 +19,7 @@
 (defmacro EXIT-FAILURE []   1) ;    Failing exit status.
 (defmacro EXIT-SUCCESS []   0) ; Successful exit status.
 (defmacro COLON        [] ":")
+(defmacro ANY-         [] "*")
 (defmacro SLASH        [] "/")
 (defmacro O-BRACKET    [] "[")
 (defmacro C-BRACKET    [] "]")

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -47,13 +47,15 @@
 (defmacro DEF-PORT "The default server port number."  [] 8080 )
 
 ; REST URI path-related constants.
-(defmacro REST-VERSION [] "v1"         )
-(defmacro REST-PREFIX  [] "customers"  )
-(defmacro REST-CUST-ID [] "customer_id")
+(defmacro REST-VERSION  [] "v1"         )
+(defmacro REST-PREFIX   [] "customers"  )
+(defmacro REST-CUST-ID  [] "customer_id")
+(defmacro REST-CONTACTS [] "contacts"   )
 
 ; HTTP response-related constants.
-(defmacro CONT-TYPE [] "content-type"    )
-(defmacro MIME-TYPE [] "application/json")
+(defmacro CONT-TYPE    [] "content-type"    )
+(defmacro MIME-TYPE    [] "application/json")
+(defmacro HDR-LOCATION [] "Location"        )
 
 ; Globals.
 (def s   "The Unix system logger."    (atom {}))

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -38,6 +38,10 @@
 (defmacro ERR-SERV-UNKNOWN-REASON []
     "for an unknown reason. Quitting...")
 (defmacro MSG-ADDR-ALREADY-IN-USE [] "Address already in use")
+(defmacro ERR-KEY [] "error")
+(defmacro ERR-REQ-NOT-FOUND-1 [] (str
+    "HTTP 404 Not Found: Bad HTTP method used or no such "
+    "REST URI path exists. Please check your inputs."))
 
 (defmacro SETTINGS "The filename of the daemon settings
     (in edn (Extensible Data Notation) format)." [] "settings.conf")

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/helper.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -47,10 +47,11 @@
 (defmacro DEF-PORT "The default server port number."  [] 8080 )
 
 ; REST URI path-related constants.
-(defmacro REST-VERSION  [] "v1"         )
-(defmacro REST-PREFIX   [] "customers"  )
-(defmacro REST-CUST-ID  [] "customer_id")
-(defmacro REST-CONTACTS [] "contacts"   )
+(defmacro REST-VERSION   [] "v1"          )
+(defmacro REST-PREFIX    [] "customers"   )
+(defmacro REST-CUST-ID   [] "customer_id" )
+(defmacro REST-CONTACTS  [] "contacts"    )
+(defmacro REST-CONT-TYPE [] "contact_type")
 
 ; HTTP response-related constants.
 (defmacro CONT-TYPE    [] "content-type"    )

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -1,7 +1,7 @@
 ;
 ; src/resources/settings.conf
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.7
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- Defining two `PUT` REST API endpoints, actually endpoint stubs: they currently return nothing except a status code with response headers.
- Defining two remaining `GET` REST API endpoints, actually endpoint stubs: they currently return nothing except a status code with response headers.
- Responding with the HTTP `404 Not Found` status code and an appropriate error message when accessing routes other than those defined and handled explicitly.
- Bumping version number to **0.1.7**.