### PR TITLE
Introduce the model namespace of the daemon. Implement `GET /v1/customers` and `GET /v1/customers/{customer_id}` REST endpoints.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -29,7 +29,7 @@ $(SRV):
 $(JAR):
 	$(LEIN) $(UBERJAR) && \
 	DAEMON_NAME="customers-api-lite"; \
-	DMN_VERSION="0.1.8"; \
+	DMN_VERSION="0.1.9"; \
 	SIMPLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}.jar"; \
 	BUNDLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}-standalone.jar"; \
 	$(RM) $${SIMPLE_JAR} && $(MV) $${BUNDLE_JAR} $${SIMPLE_JAR} && \

--- a/README.md
+++ b/README.md
@@ -147,15 +147,32 @@ The following command-line snippets display the exact usage for these endpoints 
 3. **List customers**
 
 ```
-$ curl -v http://localhost:8765
+$ curl -v http://localhost:8765/v1/customers
 ...
+> GET /v1/customers HTTP/1.1
+...
+< HTTP/1.1 200 OK
+< Content-Type: application/json
+< content-length: 66
+< Server: http-kit
+...
+[{"id":1,"name":"Jammy Jellyfish"},{"id":2,"name":"Noble Numbat"}]
 ```
-
-**TBD** :cd:
 
 4. **Retrieve customer**
 
-**TBD** :cd:
+```
+$ curl -v http://localhost:8765/v1/customers/2
+...
+> GET /v1/customers/2 HTTP/1.1
+...
+< HTTP/1.1 200 OK
+< Content-Type: application/json
+< content-length: 30
+< Server: http-kit
+...
+{"id":2,"name":"Noble Numbat"}
+```
 
 5. **List contacts for a given customer**
 
@@ -171,11 +188,15 @@ The microservice has the ability to log messages to a logfile and to the Unix sy
 
 ```
 $ tail -f log/customers-api-lite.log
-[2025-11-29][01:30:20] [DEBUG] [Customers API Lite]
-[2025-11-29][01:30:20] [DEBUG] [org.sqlite.jdbc4.JDBC4Connection@7a583586]
-[2025-11-29][01:30:20] [INFO ] Server started on port 8765
-[2025-11-29][01:30:30] [DEBUG] [GET]
-[2025-11-29][01:30:40] [INFO ] Server stopped
+[2025-12-17][02:10:20] [DEBUG] [Customers API Lite]
+[2025-12-17][02:10:20] [DEBUG] [org.sqlite.jdbc4.JDBC4Connection@4e61a863]
+[2025-12-17][02:10:20] [INFO ] Server started on port 8765
+[2025-12-17][02:10:30] [DEBUG] [GET]
+[2025-12-17][02:10:30] [DEBUG] [1|Jammy Jellyfish]
+[2025-12-17][02:10:40] [DEBUG] [GET]
+[2025-12-17][02:10:40] [DEBUG] customer_id=2
+[2025-12-17][02:10:40] [DEBUG] [2|Noble Numbat]
+[2025-12-17][02:10:50] [INFO ] Server stopped
 ```
 
 Messages registered by the Unix system logger can be seen and analyzed using the `journalctl` utility:
@@ -183,11 +204,15 @@ Messages registered by the Unix system logger can be seen and analyzed using the
 ```
 $ journalctl -f
 ...
-Nov 29 01:30:20 <hostname> java[<pid>]: [Customers API Lite]
-Nov 29 01:30:20 <hostname> java[<pid>]: [org.sqlite.jdbc4.JDBC4Connection@7a583586]
-Nov 29 01:30:20 <hostname> java[<pid>]: Server started on port 8765
-Nov 29 01:30:30 <hostname> java[<pid>]: [GET]
-Nov 29 01:30:40 <hostname> java[<pid>]: Server stopped
+Dec 17 02:10:20 <hostname> java[<pid>]: [Customers API Lite]
+Dec 17 02:10:20 <hostname> java[<pid>]: [org.sqlite.jdbc4.JDBC4Connection@4e61a863]
+Dec 17 02:10:20 <hostname> java[<pid>]: Server started on port 8765
+Dec 17 02:10:30 <hostname> java[<pid>]: [GET]
+Dec 17 02:10:30 <hostname> java[<pid>]: [1|Jammy Jellyfish]
+Dec 17 02:10:40 <hostname> java[<pid>]: [GET]
+Dec 17 02:10:40 <hostname> java[<pid>]: customer_id=2
+Dec 17 02:10:40 <hostname> java[<pid>]: [2|Noble Numbat]
+Dec 17 02:10:50 <hostname> java[<pid>]: Server stopped
 ```
 
 **TBD** :cd:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $
 $ lein uberjar && \
   UBERJAR_DIR="target/uberjar"; \
   DAEMON_NAME="customers-api-lite"; \
-  DMN_VERSION="0.1.8"; \
+  DMN_VERSION="0.1.9"; \
   SIMPLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}.jar"; \
   BUNDLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}-standalone.jar"; \
   rm ${SIMPLE_JAR} && mv ${BUNDLE_JAR} ${SIMPLE_JAR} && \
@@ -68,8 +68,8 @@ $ lein uberjar && \
 Compiling customers.api-lite.controller
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.8.jar
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.8-standalone.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.9.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.1.9-standalone.jar
 ```
 
 Or **build** the microservice using **GNU Make** (optional, but for convenience &mdash; it covers the same **Leiningen** build workflow under the hood):
@@ -95,14 +95,14 @@ $ lein run; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `uberjar` Leiningen task or GNU Make's `all` target:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.1.8.jar; echo $?
+$ java -jar target/uberjar/customers-api-lite-0.1.9.jar; echo $?
 ...
 ```
 
 To run the microservice as a *true* daemon, i.e. in the background, redirecting all the console output to `/dev/null`, the following form of invocation of its executable JAR bundle can be used:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.1.8.jar > /dev/null 2>&1 &
+$ java -jar target/uberjar/customers-api-lite-0.1.9.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 
@@ -113,7 +113,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.1.8.jar > /dev/null 2>&1
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.1.9.jar > /dev/null 2>&1
 ```
 
 ## Consuming

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+-- Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype
@@ -10,7 +10,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject customers-api-lite "0.1.8"
+(defproject customers-api-lite "0.1.9"
     :description     "Customers API Lite microservice prototype."
     :url             "https://github.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit"
     :license {

--- a/project.clj
+++ b/project.clj
@@ -18,13 +18,13 @@
         :url  "https://raw.githubusercontent.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit/main/LICENSE"
     }
     :dependencies [
-        [org.clojure/clojure               "1.12.3"  ]
+        [org.clojure/clojure               "1.12.4"  ]
         [org.clojure/tools.logging         "1.3.0"   ]
         [org.slf4j/slf4j-reload4j          "2.0.17"  ]
         [org.graylog2/syslog4j             "0.9.61"  ]
-        [net.java.dev.jna/jna              "5.18.0"  ]
+        [net.java.dev.jna/jna              "5.18.1"  ]
         [com.github.seancorfield/next.jdbc "1.3.1070"]
-        [org.xerial/sqlite-jdbc            "3.50.3.0"]
+        [org.xerial/sqlite-jdbc            "3.51.1.0"]
         [http-kit                          "2.8.1"   ]
         [compojure                         "1.7.2"   ]
         [org.clojure/data.json             "2.5.1"   ]

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -42,17 +42,14 @@
 ; Helper function. Used to send an HTTP response.
 (defn -response [body headers status]
     (let [resp {:body (write-str body) :headers {(CONT-TYPE) (MIME-TYPE)}}]
-    (-dbg (str (O-BRACKET) resp   (C-BRACKET)))
     (let [resp-  (if-not (nil? headers)
         (assoc-in resp  [:headers] (into (:headers resp) headers))
         resp
     )]
-    (-dbg (str (O-BRACKET) resp-  (C-BRACKET)))
     (let [resp-- (if-not (nil? status)
         (assoc-in resp- [:status] status)
         resp-
     )]
-    (-dbg (str (O-BRACKET) resp-- (C-BRACKET)))
     resp--)))
 )
 
@@ -283,10 +280,9 @@
 
     ; For any other route Compojure will automatically respond
     ; with the HTTP 404 Not Found status code.
-    (not-found {:headers {
-        (CONT-TYPE) (MIME-TYPE)
-    } :body
-        (write-str {:error (ERR-REQ-NOT-FOUND-1)})
+    (not-found {
+        :body (write-str {:error (ERR-REQ-NOT-FOUND-1)})
+        :headers {(CONT-TYPE) (MIME-TYPE)}
     })
 )
 

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -39,6 +39,17 @@
     (-dbg (str (O-BRACKET) method (C-BRACKET)))))
 )
 
+; Helper function. Used to send an HTTP response.
+(defn -response [body headers status]
+    (let [resp   {:headers {(CONT-TYPE) (MIME-TYPE)}  :body (write-str  body)}]
+    (-dbg (str (O-BRACKET) resp   (C-BRACKET)))
+    (let [resp-  (if-not (nil? headers) (merge resp  {:headers headers}) resp)]
+    (-dbg (str (O-BRACKET) resp-  (C-BRACKET)))
+    (let [resp-- (if-not (nil? status ) (merge resp- {:status status})  resp-)]
+    (-dbg (str (O-BRACKET) resp-- (C-BRACKET)))
+    resp--)))
+)
+
 ; REST API endpoints ----------------------------------------------------------
 
 (defn add-customer
@@ -68,12 +79,13 @@
 
     (-method req)
 
-    {:status 201 :headers {
+    ; TODO: Create a new customer (put customer data to the database).
+
+    (-response (str) {
         (HDR-LOCATION) (str (SLASH) (REST-VERSION)
                             (SLASH) (REST-PREFIX)
-                            (SLASH) "?")
-        (CONT-TYPE) (MIME-TYPE)
-    }}
+                            (SLASH) (EQUALS))
+    } 201)
 )
 
 (defn add-contact
@@ -106,14 +118,16 @@
 
     (-method req)
 
-    {:status 201 :headers {
+    ; TODO: Create a new contact (put a contact regarding a given customer
+    ;       to the database).
+
+    (-response (str) {
         (HDR-LOCATION) (str (SLASH) (REST-VERSION)
                             (SLASH) (REST-PREFIX)
-                            (SLASH) "?"
+                            (SLASH) (EQUALS)
                             (SLASH) (REST-CONTACTS)
-                            (SLASH) "?")
-        (CONT-TYPE) (MIME-TYPE)
-    }}
+                            (SLASH) (EQUALS))
+    } 201)
 )
 
 (defn list-customers
@@ -140,11 +154,7 @@
                (V-BAR)     (get customer0 :customers/name) ; getName()
                (C-BRACKET))))
 
-    {:headers {
-        (CONT-TYPE) (MIME-TYPE)
-    } :body
-        (write-str customers)
-    })
+    (-response customers nil nil))
 )
 
 (defn get-customer
@@ -174,11 +184,7 @@
                (V-BAR)     (get customer :customers/name) ; getName()
                (C-BRACKET)))
 
-    {:headers {
-        (CONT-TYPE) (MIME-TYPE)
-    } :body
-        (write-str customer)
-    })))
+    (-response customer nil nil))))
 )
 
 (defn list-contacts
@@ -198,16 +204,15 @@
 
     (-method req)
 
-    {:headers {
-        (CONT-TYPE) (MIME-TYPE)
-    } :body
-        (write-str [
-            {:contact (COLON)}
-            {:contact (SLASH)}
-            {:contact (O-BRACKET)}
-            {:contact (C-BRACKET)}
-        ])
-    }
+    ; TODO: Retrieve all contacts associated with a given customer
+    ;       from the database.
+
+    (-response [
+        {:contact (COLON)}
+        {:contact (SLASH)}
+        {:contact (O-BRACKET)}
+        {:contact (C-BRACKET)}
+    ] nil nil)
 )
 
 (defn list-contacts-by-type
@@ -228,14 +233,13 @@
 
     (-method req)
 
-    {:headers {
-        (CONT-TYPE) (MIME-TYPE)
-    } :body
-        (write-str [
-            {:contact (COLON)}
-            {:contact (SLASH)}
-        ])
-    }
+    ; TODO: Retrieve all contacts of a given type associated
+    ;       with a given customer from the database.
+
+    (-response [
+        {:contact (COLON)}
+        {:contact (SLASH)}
+    ] nil nil)
 )
 
 ; -----------------------------------------------------------------------------

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -136,6 +136,11 @@
     (let [customers (execute! @cnx [(SQL-GET-ALL-CUSTOMERS)])]
     (-dbg (str (O-BRACKET) customers (C-BRACKET)))
 
+    (let [customer0 (nth customers 0)]
+    (-dbg (str (O-BRACKET) (get customer0 :customers/id  ) ; getId()
+               (V-BAR)     (get customer0 :customers/name) ; getName()
+               (C-BRACKET))))
+
     {:headers {
         (CONT-TYPE) (MIME-TYPE)
     } :body

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/controller.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -11,10 +11,14 @@
 ;
 
 (ns customers.api-lite.controller "The controller namespace of the daemon."
-    (:use     [customers.api-lite.helper])
+    (:use     [customers.api-lite.helper]
+              [customers.api-lite.model ])
     (:require [clojure.string    :as s  ]
               [clojure.data.json :refer [
                   write-str
+              ]]
+              [next.jdbc         :refer [
+                  execute!
               ]]
               [compojure.core    :refer [
                   defroutes
@@ -128,14 +132,15 @@
 
     (-method req)
 
+    ; Retrieving all customer profiles from the database.
+    (let [customers (execute! @cnx [(SQL-GET-ALL-CUSTOMERS)])]
+    (-dbg (str (O-BRACKET) customers (C-BRACKET)))
+
     {:headers {
         (CONT-TYPE) (MIME-TYPE)
     } :body
-        (write-str [
-            {:id 1 :name (COLON)}
-            {:id 2 :name (SLASH)}
-        ])
-    }
+        (write-str customers)
+    })
 )
 
 (defn get-customer
@@ -154,11 +159,19 @@
 
     (-method req)
 
+    (let [customer_id- (get req :params)]
+    (let [customer_id  (get customer_id- :customer_id)]
+    (-dbg (str (O-BRACKET) customer_id (C-BRACKET)))
+
+    ; Retrieving profile details for a given customer from the database.
+    (let [customer (execute! @cnx [(SQL-GET-CUSTOMER-BY-ID) customer_id])]
+    (-dbg (str (O-BRACKET) customer (C-BRACKET)))
+
     {:headers {
         (CONT-TYPE) (MIME-TYPE)
     } :body
-        (write-str {:id 3 :name (COLON)})
-    }
+        (write-str customer)
+    })))
 )
 
 (defn list-contacts

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -41,11 +41,17 @@
 
 ; Helper function. Used to send an HTTP response.
 (defn -response [body headers status]
-    (let [resp   {:headers {(CONT-TYPE) (MIME-TYPE)}  :body (write-str  body)}]
+    (let [resp {:body (write-str body) :headers {(CONT-TYPE) (MIME-TYPE)}}]
     (-dbg (str (O-BRACKET) resp   (C-BRACKET)))
-    (let [resp-  (if-not (nil? headers) (merge resp  {:headers headers}) resp)]
+    (let [resp-  (if-not (nil? headers)
+        (assoc-in resp  [:headers] (into (:headers resp) headers))
+        resp
+    )]
     (-dbg (str (O-BRACKET) resp-  (C-BRACKET)))
-    (let [resp-- (if-not (nil? status ) (merge resp- {:status status})  resp-)]
+    (let [resp-- (if-not (nil? status)
+        (assoc-in resp- [:status] status)
+        resp-
+    )]
     (-dbg (str (O-BRACKET) resp-- (C-BRACKET)))
     resp--)))
 )

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -164,13 +164,17 @@
 
     (-method req)
 
-    (let [customer_id- (get req :params)]
-    (let [customer_id  (get customer_id- :customer_id)]
-    (-dbg (str (O-BRACKET) customer_id (C-BRACKET)))
+    (let [customer-id (-> req :params :customer_id)]
+    (-dbg (str (REST-CUST-ID) (EQUALS) customer-id))
 
     ; Retrieving profile details for a given customer from the database.
-    (let [customer (execute! @cnx [(SQL-GET-CUSTOMER-BY-ID) customer_id])]
-    (-dbg (str (O-BRACKET) customer (C-BRACKET)))
+    (let [customer- (execute! @cnx [(SQL-GET-CUSTOMER-BY-ID) customer-id])]
+    (-dbg (str (O-BRACKET) customer- (C-BRACKET)))
+
+    (let [customer (nth customer- 0)]
+    (-dbg (str (O-BRACKET) (get customer :customers/id  ) ; getId()
+               (V-BAR)     (get customer :customers/name) ; getName()
+               (C-BRACKET)))
 
     {:headers {
         (CONT-TYPE) (MIME-TYPE)

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -134,7 +134,6 @@
 
     ; Retrieving all customer profiles from the database.
     (let [customers (execute! @cnx [(SQL-GET-ALL-CUSTOMERS)])]
-    (-dbg (str (O-BRACKET) customers (C-BRACKET)))
 
     (let [customer0 (nth customers 0)]
     (-dbg (str (O-BRACKET) (get customer0 :customers/id  ) ; getId()
@@ -169,7 +168,6 @@
 
     ; Retrieving profile details for a given customer from the database.
     (let [customer- (execute! @cnx [(SQL-GET-CUSTOMER-BY-ID) customer-id])]
-    (-dbg (str (O-BRACKET) customer- (C-BRACKET)))
 
     (let [customer (nth customer- 0)]
     (-dbg (str (O-BRACKET) (get customer :customers/id  ) ; getId()

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/core.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -20,6 +20,7 @@
 (defmacro EXIT-SUCCESS []   0) ; Successful exit status.
 (defmacro COLON        [] ":")
 (defmacro SLASH        [] "/")
+(defmacro V-BAR        [] "|")
 (defmacro O-BRACKET    [] "[")
 (defmacro C-BRACKET    [] "]")
 

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -21,6 +21,7 @@
 (defmacro COLON        [] ":")
 (defmacro SLASH        [] "/")
 (defmacro V-BAR        [] "|")
+(defmacro EQUALS       [] "=")
 (defmacro O-BRACKET    [] "[")
 (defmacro C-BRACKET    [] "]")
 

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/helper.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/model.clj
+++ b/src/customers/api_lite/model.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/model.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/model.clj
+++ b/src/customers/api_lite/model.clj
@@ -1,0 +1,37 @@
+;
+; src/customers/api_lite/model.clj
+; =============================================================================
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+; =============================================================================
+; A daemon written in Clojure, designed and intended to be run
+; as a microservice, implementing a special Customers API prototype
+; with a smart yet simplified data scheme.
+; =============================================================================
+; (See the LICENSE file at the top of the source tree.)
+;
+
+(ns customers.api-lite.model "The model namespace of the daemon.")
+
+; The SQL query for retrieving all customer profiles.
+;
+; Used by the `GET /v1/customers` REST endpoint.
+(defmacro SQL-GET-ALL-CUSTOMERS [] (str
+    "select id ," ; as 'Customer ID'
+    "       name" ; as 'Customer Name'
+    " from"
+    "       customers"
+    " order by"
+    "       id"))
+
+; The SQL query for retrieving profile details for a given customer.
+;
+; Used by the `GET /v1/customers/{customer_id}` REST endpoint.
+(defmacro SQL-GET-CUSTOMER-BY-ID [] (str
+    "select id ," ; as 'Customer ID'
+    "       name" ; as 'Customer Name'
+    " from"
+    "       customers"
+    " where"
+    "      (id = ?)"))
+
+; vim:set nu et ts=4 sw=4:

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+# Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -1,7 +1,7 @@
 ;
 ; src/resources/settings.conf
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.1.8
+; Customers API Lite microservice prototype (Clojure port). Version 0.1.9
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- **Dependencies:** Updating **Clojure** to version **1.12.4**, updating **JNA (Java Native Access)** to version **5.18.1**, updating **SQLite JDBC** to version **3.51.1.0**.
- Introducing the model namespace of the daemon, defining two SQL queries for the first two `GET` REST endpoints.
- Implementing `GET /v1/customers` and `GET /v1/customers/{customer_id}` REST endpoints.
- Introducing a helper function that is used to send HTTP responses &mdash; to reduce writing repetitive constructs in endpoints.
- **Bugfix:** Adding extra response headers to those already exist in a map, not just replacing the former.
- Exposing command-line snippets for accessing first two `GET` REST endpoints with related diagnostics output.
- Bumping version number to **0.1.9**.