### PR TITLE
Incorporate the HikariCP JDBC connection pool library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+# Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+# Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -29,7 +29,7 @@ $(SRV):
 $(JAR):
 	$(LEIN) $(UBERJAR) && \
 	DAEMON_NAME="customers-api-lite"; \
-	DMN_VERSION="0.2.4"; \
+	DMN_VERSION="0.2.5"; \
 	SIMPLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}.jar"; \
 	BUNDLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}-standalone.jar"; \
 	$(RM) $${SIMPLE_JAR} && $(MV) $${BUNDLE_JAR} $${SIMPLE_JAR} && \

--- a/README.md
+++ b/README.md
@@ -284,54 +284,28 @@ The microservice has the ability to log messages to a logfile and to the Unix sy
 
 ```
 $ tail -f log/customers-api-lite.log
-[2025-12-29][15:10:00] [DEBUG] [Customers API Lite]
-[2025-12-29][15:10:00] [DEBUG] [org.sqlite.jdbc4.JDBC4Connection@398694a6]
-[2025-12-29][15:10:00] [INFO ] Server started on port 8765
-[2025-12-29][15:10:30] [DEBUG] [PUT]
-[2025-12-29][15:10:30] [DEBUG] [Jamison Palmer]
-[2025-12-29][15:10:30] [DEBUG] [3|Jamison Palmer]
-[2025-12-29][15:10:50] [DEBUG] [PUT]
-[2025-12-29][15:10:50] [DEBUG] [Sarah Kitteringham]
-[2025-12-29][15:10:50] [DEBUG] [4|Sarah Kitteringham]
-[2025-12-29][15:11:10] [DEBUG] [PUT]
-[2025-12-29][15:11:10] [DEBUG] customer_id=3
-[2025-12-29][15:11:10] [DEBUG] [+12197654320]
-[2025-12-29][15:11:10] [DEBUG] [phone|+12197654320]
-[2025-12-29][15:11:40] [DEBUG] [PUT]
-[2025-12-29][15:11:40] [DEBUG] customer_id=3
-[2025-12-29][15:11:40] [DEBUG] [+12197654321]
-[2025-12-29][15:11:40] [DEBUG] [phone|+12197654321]
-[2025-12-29][15:12:00] [DEBUG] [PUT]
-[2025-12-29][15:12:00] [DEBUG] customer_id=3
-[2025-12-29][15:12:00] [DEBUG] [+12197654322]
-[2025-12-29][15:12:00] [DEBUG] [phone|+12197654322]
-[2025-12-29][15:12:20] [DEBUG] [PUT]
-[2025-12-29][15:12:20] [DEBUG] customer_id=3
-[2025-12-29][15:12:20] [DEBUG] [jamison.palmer@example.com]
-[2025-12-29][15:12:20] [DEBUG] [email|jamison.palmer@example.com]
-[2025-12-29][15:12:40] [DEBUG] [PUT]
-[2025-12-29][15:12:40] [DEBUG] customer_id=3
-[2025-12-29][15:12:40] [DEBUG] [jpalmer@example.com]
-[2025-12-29][15:12:40] [DEBUG] [email|jpalmer@example.com]
-[2025-12-29][15:12:50] [DEBUG] [PUT]
-[2025-12-29][15:12:50] [DEBUG] customer_id=3
-[2025-12-29][15:12:50] [DEBUG] [jp@example.com]
-[2025-12-29][15:12:50] [DEBUG] [email|jp@example.com]
-[2025-12-29][15:13:10] [DEBUG] [GET]
-[2025-12-29][15:13:10] [DEBUG] [1|Jammy Jellyfish]
-[2025-12-29][15:13:20] [DEBUG] [GET]
-[2025-12-29][15:13:20] [DEBUG] customer_id=3
-[2025-12-29][15:13:20] [DEBUG] [3|Jamison Palmer]
-[2025-12-29][15:13:30] [DEBUG] [GET]
-[2025-12-29][15:13:30] [DEBUG] customer_id=3
-[2025-12-29][15:13:30] [DEBUG] [+12197654320]
-[2025-12-29][15:13:40] [DEBUG] [GET]
-[2025-12-29][15:13:40] [DEBUG] customer_id=3 | contact_type=phone
-[2025-12-29][15:13:40] [DEBUG] [+12197654320]
-[2025-12-29][15:13:50] [DEBUG] [GET]
-[2025-12-29][15:13:50] [DEBUG] customer_id=3 | contact_type=email
-[2025-12-29][15:13:50] [DEBUG] [jamison.palmer@example.com]
-[2025-12-29][15:14:00] [INFO ] Server stopped
+[2025-12-31][00:10:00] [DEBUG] [Customers API Lite]
+[2025-12-31][00:10:00] [INFO ] HikariPool-1 - Starting...
+[2025-12-31][00:10:00] [INFO ] HikariPool-1 - Added connection org.sqlite.jdbc4.JDBC4Connection@56a09a5c
+[2025-12-31][00:10:00] [INFO ] HikariPool-1 - Start completed.
+[2025-12-31][00:10:00] [DEBUG] [HikariProxyConnection@1198265211 wrapping org.sqlite.jdbc4.JDBC4Connection@56a09a5c]
+[2025-12-31][00:10:00] [INFO ] Server started on port 8765
+[2025-12-31][00:10:30] [DEBUG] [PUT]
+[2025-12-31][00:10:30] [DEBUG] [Saturday Sunday]
+[2025-12-31][00:10:30] [DEBUG] [5|Saturday Sunday]
+[2025-12-31][00:10:50] [DEBUG] [PUT]
+[2025-12-31][00:10:50] [DEBUG] customer_id=5
+[2025-12-31][00:10:50] [DEBUG] [Saturday.Sunday@example.com]
+[2025-12-31][00:10:50] [DEBUG] [email|Saturday.Sunday@example.com]
+[2025-12-31][00:11:10] [DEBUG] [GET]
+[2025-12-31][00:11:10] [DEBUG] customer_id=5
+[2025-12-31][00:11:10] [DEBUG] [5|Saturday Sunday]
+[2025-12-31][00:11:40] [DEBUG] [GET]
+[2025-12-31][00:11:40] [DEBUG] customer_id=5 | contact_type=email
+[2025-12-31][00:11:40] [DEBUG] [Saturday.Sunday@example.com]
+[2025-12-31][00:12:00] [INFO ] Server stopped
+[2025-12-31][00:12:00] [INFO ] HikariPool-1 - Shutdown initiated...
+[2025-12-31][00:12:00] [INFO ] HikariPool-1 - Shutdown completed.
 ```
 
 Messages registered by the Unix system logger can be seen and analyzed using the `journalctl` utility:
@@ -339,54 +313,23 @@ Messages registered by the Unix system logger can be seen and analyzed using the
 ```
 $ journalctl -f
 ...
-Dec 29 15:10:00 <hostname> java[<pid>]: [Customers API Lite]
-Dec 29 15:10:00 <hostname> java[<pid>]: [org.sqlite.jdbc4.JDBC4Connection@398694a6]
-Dec 29 15:10:00 <hostname> java[<pid>]: Server started on port 8765
-Dec 29 15:10:30 <hostname> java[<pid>]: [PUT]
-Dec 29 15:10:30 <hostname> java[<pid>]: [Jamison Palmer]
-Dec 29 15:10:30 <hostname> java[<pid>]: [3|Jamison Palmer]
-Dec 29 15:10:50 <hostname> java[<pid>]: [PUT]
-Dec 29 15:10:50 <hostname> java[<pid>]: [Sarah Kitteringham]
-Dec 29 15:10:50 <hostname> java[<pid>]: [4|Sarah Kitteringham]
-Dec 29 15:11:10 <hostname> java[<pid>]: [PUT]
-Dec 29 15:11:10 <hostname> java[<pid>]: customer_id=3
-Dec 29 15:11:10 <hostname> java[<pid>]: [+12197654320]
-Dec 29 15:11:10 <hostname> java[<pid>]: [phone|+12197654320]
-Dec 29 15:11:40 <hostname> java[<pid>]: [PUT]
-Dec 29 15:11:40 <hostname> java[<pid>]: customer_id=3
-Dec 29 15:11:40 <hostname> java[<pid>]: [+12197654321]
-Dec 29 15:11:40 <hostname> java[<pid>]: [phone|+12197654321]
-Dec 29 15:12:00 <hostname> java[<pid>]: [PUT]
-Dec 29 15:12:00 <hostname> java[<pid>]: customer_id=3
-Dec 29 15:12:00 <hostname> java[<pid>]: [+12197654322]
-Dec 29 15:12:00 <hostname> java[<pid>]: [phone|+12197654322]
-Dec 29 15:12:20 <hostname> java[<pid>]: [PUT]
-Dec 29 15:12:20 <hostname> java[<pid>]: customer_id=3
-Dec 29 15:12:20 <hostname> java[<pid>]: [jamison.palmer@example.com]
-Dec 29 15:12:20 <hostname> java[<pid>]: [email|jamison.palmer@example.com]
-Dec 29 15:12:40 <hostname> java[<pid>]: [PUT]
-Dec 29 15:12:40 <hostname> java[<pid>]: customer_id=3
-Dec 29 15:12:40 <hostname> java[<pid>]: [jpalmer@example.com]
-Dec 29 15:12:40 <hostname> java[<pid>]: [email|jpalmer@example.com]
-Dec 29 15:12:50 <hostname> java[<pid>]: [PUT]
-Dec 29 15:12:50 <hostname> java[<pid>]: customer_id=3
-Dec 29 15:12:50 <hostname> java[<pid>]: [jp@example.com]
-Dec 29 15:12:50 <hostname> java[<pid>]: [email|jp@example.com]
-Dec 29 15:13:10 <hostname> java[<pid>]: [GET]
-Dec 29 15:13:10 <hostname> java[<pid>]: [1|Jammy Jellyfish]
-Dec 29 15:13:20 <hostname> java[<pid>]: [GET]
-Dec 29 15:13:20 <hostname> java[<pid>]: customer_id=3
-Dec 29 15:13:20 <hostname> java[<pid>]: [3|Jamison Palmer]
-Dec 29 15:13:30 <hostname> java[<pid>]: [GET]
-Dec 29 15:13:30 <hostname> java[<pid>]: customer_id=3
-Dec 29 15:13:30 <hostname> java[<pid>]: [+12197654320]
-Dec 29 15:13:40 <hostname> java[<pid>]: [GET]
-Dec 29 15:13:40 <hostname> java[<pid>]: customer_id=3 | contact_type=phone
-Dec 29 15:13:40 <hostname> java[<pid>]: [+12197654320]
-Dec 29 15:13:50 <hostname> java[<pid>]: [GET]
-Dec 29 15:13:50 <hostname> java[<pid>]: customer_id=3 | contact_type=email
-Dec 29 15:13:50 <hostname> java[<pid>]: [jamison.palmer@example.com]
-Dec 29 15:14:00 <hostname> java[<pid>]: Server stopped
+Dec 31 00:10:00 <hostname> java[<pid>]: [Customers API Lite]
+Dec 31 00:10:00 <hostname> java[<pid>]: [HikariProxyConnection@1198265211 wrapping org.sqlite.jdbc4.JDBC4Connection@56a09a5c]
+Dec 31 00:10:00 <hostname> java[<pid>]: Server started on port 8765
+Dec 31 00:10:30 <hostname> java[<pid>]: [PUT]
+Dec 31 00:10:30 <hostname> java[<pid>]: [Saturday Sunday]
+Dec 31 00:10:30 <hostname> java[<pid>]: [5|Saturday Sunday]
+Dec 31 00:10:50 <hostname> java[<pid>]: [PUT]
+Dec 31 00:10:50 <hostname> java[<pid>]: customer_id=5
+Dec 31 00:10:50 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
+Dec 31 00:10:50 <hostname> java[<pid>]: [email|Saturday.Sunday@example.com]
+Dec 31 00:11:10 <hostname> java[<pid>]: [GET]
+Dec 31 00:11:10 <hostname> java[<pid>]: customer_id=5
+Dec 31 00:11:10 <hostname> java[<pid>]: [5|Saturday Sunday]
+Dec 31 00:11:40 <hostname> java[<pid>]: [GET]
+Dec 31 00:11:40 <hostname> java[<pid>]: customer_id=5 | contact_type=email
+Dec 31 00:11:40 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
+Dec 31 00:12:00 <hostname> java[<pid>]: Server stopped
 ```
 
 **TBD** :cd:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $
 $ lein uberjar && \
   UBERJAR_DIR="target/uberjar"; \
   DAEMON_NAME="customers-api-lite"; \
-  DMN_VERSION="0.2.4"; \
+  DMN_VERSION="0.2.5"; \
   SIMPLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}.jar"; \
   BUNDLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}-standalone.jar"; \
   rm ${SIMPLE_JAR} && mv ${BUNDLE_JAR} ${SIMPLE_JAR} && \
@@ -70,8 +70,8 @@ Compiling customers.api-lite.controller
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
 Compiling customers.api-lite.model
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.2.4.jar
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.2.4-standalone.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.2.5.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.2.5-standalone.jar
 ```
 
 Or **build** the microservice using **GNU Make** (optional, but for convenience &mdash; it covers the same **Leiningen** build workflow under the hood):
@@ -97,14 +97,14 @@ $ lein run; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `uberjar` Leiningen task or GNU Make's `all` target:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.2.4.jar; echo $?
+$ java -jar target/uberjar/customers-api-lite-0.2.5.jar; echo $?
 ...
 ```
 
 To run the microservice as a *true* daemon, i.e. in the background, redirecting all the console output to `/dev/null`, the following form of invocation of its executable JAR bundle can be used:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.2.4.jar > /dev/null 2>&1 &
+$ java -jar target/uberjar/customers-api-lite-0.2.5.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 
@@ -115,7 +115,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.2.4.jar > /dev/null 2>&1
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.2.5.jar > /dev/null 2>&1
 ```
 
 ## Consuming

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+-- Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+-- Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+-- Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+-- Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+; Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype
@@ -10,7 +10,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject customers-api-lite "0.2.4"
+(defproject customers-api-lite "0.2.5"
     :description     "Customers API Lite microservice prototype."
     :url             "https://github.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit"
     :license {

--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,7 @@
         [net.java.dev.jna/jna              "5.18.1"  ]
         [com.github.seancorfield/next.jdbc "1.3.1070"]
         [org.xerial/sqlite-jdbc            "3.51.1.0"]
+        [hikari-cp                         "3.3.0"   ]
         [http-kit                          "2.8.1"   ]
         [compojure                         "1.7.2"   ]
         [org.clojure/data.json             "2.5.1"   ]

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
         [org.slf4j/slf4j-reload4j          "2.0.17"  ]
         [org.graylog2/syslog4j             "0.9.61"  ]
         [net.java.dev.jna/jna              "5.18.1"  ]
-        [com.github.seancorfield/next.jdbc "1.3.1070"]
+        [com.github.seancorfield/next.jdbc "1.3.1086"]
         [org.xerial/sqlite-jdbc            "3.51.1.0"]
         [hikari-cp                         "3.3.0"   ]
         [http-kit                          "2.8.1"   ]

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/controller.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+; Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -51,11 +51,11 @@
     (let [datasource-url (:sqlite.datasource.url settings)]
 
     ; Making the HikariCP-based datasource.
-    (let [datasource (delay (cp/make-datasource {:jdbc-url datasource-url}))]
+    (reset! hds (cp/make-datasource {:jdbc-url datasource-url})))
 
     ; Connecting to the database.
-    (reset! cnx (db/get-connection (db/get-datasource @datasource)))
-    (-dbg (str (O-BRACKET) @cnx (C-BRACKET)))))
+    (reset! cnx (db/get-connection@hds))
+    (-dbg (str (O-BRACKET) @cnx (C-BRACKET)))
 
     ; Getting the port number used to run the http-kit web server.
     (let [server-port (-get-server-port settings)]

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/core.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+; Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -17,6 +17,7 @@
     (:use     [customers.api-lite.helper    ]
               [customers.api-lite.controller])
     (:require [clojure.tools.logging :as l  ]
+              [hikari-cp.core        :as cp ]
               [next.jdbc             :as db ]
               [org.httpkit.server    :refer [
                   run-server
@@ -49,9 +50,12 @@
     ; Getting the SQLite database JDBC URL.
     (let [datasource-url (:sqlite.datasource.url settings)]
 
+    ; Making the HikariCP-based datasource.
+    (let [datasource (delay (cp/make-datasource {:jdbc-url datasource-url}))]
+
     ; Connecting to the database.
-    (reset! cnx (db/get-connection (db/get-datasource datasource-url)))
-    (-dbg (str (O-BRACKET) @cnx (C-BRACKET))))
+    (reset! cnx (db/get-connection (db/get-datasource @datasource)))
+    (-dbg (str (O-BRACKET) @cnx (C-BRACKET)))))
 
     ; Getting the port number used to run the http-kit web server.
     (let [server-port (-get-server-port settings)]

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/helper.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+; Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -13,7 +13,8 @@
 (ns customers.api-lite.helper "The helper namespace for the daemon."
     (:require [clojure.tools.logging :as l  ]
               [clojure.java.io       :as io ]
-              [clojure.edn           :as edn]))
+              [clojure.edn           :as edn]
+              [hikari-cp.core        :as cp ]))
 
 ; Helper constants.
 (defmacro EXIT-FAILURE []   1) ;    Failing exit status.
@@ -83,9 +84,10 @@
 (defmacro EMAIL-REGEX [] #".{1,63}@.{3,190}")
 
 ; Globals.
-(def s   "The Unix system logger."    (atom {}))
-(def dbg "The debug logging enabler." (atom {}))
-(def cnx "The database connection."   (atom {}))
+(def s   "The Unix system logger."        (atom {}))
+(def dbg "The debug logging enabler."     (atom {}))
+(def cnx "The database connection."       (atom {}))
+(def hds "The HikariCP-based datasource." (atom {}))
 
 ; Helper function. Used to get the daemon settings.
 (defn -get-settings [] (edn/read-string (slurp (io/resource (SETTINGS)))))
@@ -117,6 +119,7 @@
 ; Helper function. Makes final cleanups, closes streams, etc.
 (defn -cleanup []
     (.close@cnx)
+    (cp/close-datasource@hds)
 
     ; Closing the system logger.
     ; Calling <syslog.h> closelog();

--- a/src/customers/api_lite/model.clj
+++ b/src/customers/api_lite/model.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/model.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+; Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+# Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -1,7 +1,7 @@
 ;
 ; src/resources/settings.conf
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.4
+; Customers API Lite microservice prototype (Clojure port). Version 0.2.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- Adding a dependency: `hikari-cp` (**A Clojure wrapper to HikariCP JDBC connection pool**).
- Making the HikariCP-based datasource and utilizing it constantly.
- Updating `next.jdbc` to version **1.3.1086**.
- Exposing fresh log entries after incorporating the **HikariCP JDBC connection pool** library.
- Bumping version number to **0.2.5**.