### PR TITLE
Handle properly `POST`, `PATCH`, `DELETE`, and `OPTIONS` HTTP methods.

### DIFF
--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -26,8 +26,8 @@
               [compojure.core    :refer [
                   defroutes
                   context
-                  PUT
-                  GET
+                  PUT GET
+                  POST PATCH DELETE OPTIONS
               ]]
               [compojure.route   :refer [
                   not-found
@@ -404,6 +404,9 @@
     )))))
 )
 
+; Unused specific routes fall here - just to respond with HTTP 405.
+(defn ?405 [_] {:headers {(HDR-ALLOW) (USED-METHODS)} :status (HTTP-405)})
+
 ; -----------------------------------------------------------------------------
 
 (defroutes api-lite-routes
@@ -436,6 +439,11 @@
         (GET (str (SLASH) (COLON) (REST-CUST-ID)
                   (SLASH)         (REST-CONTACTS)
                   (SLASH) (COLON) (REST-CONT-TYPE)) [] list-contacts-by-type))
+
+    (POST    (str (SLASH) (ANY)) [] ?405)
+    (PATCH   (str (SLASH) (ANY)) [] ?405)
+    (DELETE  (str (SLASH) (ANY)) [] ?405)
+    (OPTIONS (str (SLASH) (ANY)) [] ?405)
 
     ; For any other route Compojure will automatically respond
     ; with the HTTP 404 Not Found status code.

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -42,13 +42,13 @@
     (let [settings (-get-settings)]
 
     ; Identifying whether debug logging is enabled.
-    (reset! dbg (:logger.debug.enabled settings))
+    (reset! dbg (:logger-debug-enabled settings))
 
-    (let [daemon-name (:daemon.name settings)]
+    (let [daemon-name (:daemon-name settings)]
     (-dbg (str (O-BRACKET) daemon-name (C-BRACKET))))
 
     ; Getting the SQLite database JDBC URL.
-    (let [datasource-url (:sqlite.datasource.url settings)]
+    (let [datasource-url (:sqlite-datasource-url settings)]
 
     ; Making the HikariCP-based datasource.
     (reset! hds (cp/make-datasource {:jdbc-url datasource-url})))

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -95,7 +95,7 @@
 ; Helper function. Retrieves the port number used to run the http-kit
 ;                  web server, from daemon settings.
 (defn -get-server-port [settings]
-    (let [server-port (:server.port settings)]
+    (let [server-port (:server-port settings)]
 
     (if-not (nil? server-port)
         (cond

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -21,6 +21,7 @@
 (defmacro EXIT-SUCCESS []   0) ; Successful exit status.
 (defmacro SPACE        [] " ")
 (defmacro SLASH        [] "/")
+(defmacro ANY          [] "*")
 (defmacro COLON        [] ":")
 (defmacro V-BAR        [] "|")
 (defmacro EQUALS       [] "=")
@@ -73,11 +74,14 @@
 (defmacro HTTP-201 [] 201)
 (defmacro HTTP-400 [] 400)
 (defmacro HTTP-404 [] 404)
+(defmacro HTTP-405 [] 405)
 
 ; HTTP response-related constants.
 (defmacro CONT-TYPE    [] "content-type"    )
 (defmacro MIME-TYPE    [] "application/json")
 (defmacro HDR-LOCATION [] "Location"        )
+(defmacro HDR-ALLOW    [] "Allow"           )
+(defmacro USED-METHODS [] "PUT, GET, HEAD"  )
 
 ; Regex patterns for contact phones and emails.
 (defmacro PHONE-REGEX [] #"^\+\d{9,14}"     )

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -10,13 +10,13 @@
 ; (See the LICENSE file at the top of the source tree.)
 {
 
-:daemon.name "Customers API Lite"
+:daemon-name "Customers API Lite"
 
-:server.port 8765
+:server-port 8765
 
 ; Uncomment this setting to enable debug logging.
-;:logger.debug.enabled true
+;:logger-debug-enabled true
 
-:sqlite.datasource.url "jdbc:sqlite:data/db/customers-api-lite.db"
+:sqlite-datasource-url "jdbc:sqlite:data/db/customers-api-lite.db"
 
 }; vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Handling properly `POST`, `PATCH`, `DELETE`, and `OPTIONS` HTTP methods &mdash; responding with `HTTP 405`, not with `HTTP 404`.
- **Refactoring:** Replace _dot_ separators (**Java**) to _hyphen_ separators (**Lisp**) in properties naming.