### PR TITLE
Containerize the microservice with Docker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+#
+# Dockerfile
+# =============================================================================
+# Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+# =============================================================================
+# A daemon written in Clojure, designed and intended to be run
+# as a microservice, implementing a special Customers API prototype
+# with a smart yet simplified data scheme.
+# =============================================================================
+# (See the LICENSE file at the top of the source tree.)
+#
+
+# Note: Since it is supposed that all-in-one JAR bundle of the microservice
+#       was already built previously and can be run in a container as is,
+#       there is no need to use official Clojure Docker images
+#       (https://hub.docker.com/_/clojure).
+#       Instead, it is recommended to use any of JRE-only flavors of slim
+#       (e.g. Alpine-based) Docker images.
+
+FROM       azul/zulu-openjdk-alpine:21-jre-headless-latest
+USER       daemon
+WORKDIR    var/tmp
+COPY       target/uberjar/customers-api-lite-0.2.6.jar api-lite/api-lite.jar
+COPY       data/db                                     api-lite/data/db/
+WORKDIR    api-lite
+USER       root
+RUN        ["chown", "-R", "daemon:daemon", "."]
+USER       daemon
+ENTRYPOINT ["java", "-jar", "api-lite.jar"]
+
+# vim:set nu ts=4 sw=4:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Dockerfile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -20,7 +20,7 @@
 FROM       azul/zulu-openjdk-alpine:21-jre-headless-latest
 USER       daemon
 WORKDIR    var/tmp
-COPY       target/uberjar/customers-api-lite-0.2.6.jar api-lite/api-lite.jar
+COPY       target/uberjar/customers-api-lite-0.3.0.jar api-lite/api-lite.jar
 COPY       data/db                                     api-lite/data/db/
 WORKDIR    api-lite
 USER       root

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype
@@ -29,7 +29,7 @@ $(SRV):
 $(JAR):
 	$(LEIN) $(UBERJAR) && \
 	DAEMON_NAME="customers-api-lite"; \
-	DMN_VERSION="0.2.6"; \
+	DMN_VERSION="0.3.0"; \
 	SIMPLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}.jar"; \
 	BUNDLE_JAR="$(JAR)/$${DAEMON_NAME}-$${DMN_VERSION}-standalone.jar"; \
 	$(RM) $${SIMPLE_JAR} && $(MV) $${BUNDLE_JAR} $${SIMPLE_JAR} && \

--- a/README.md
+++ b/README.md
@@ -433,7 +433,58 @@ Feb 15 15:11:40 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
 Feb 15 15:12:00 <hostname> java[<pid>]: Server stopped
 ```
 
-**TBD** :cd:
+Inside the running container logs might be queried also by `tail`ing the `log/customers-api-lite.log` logfile:
+
+```
+/var/tmp/api-lite $ tail -f log/customers-api-lite.log
+[2026-02-15][18:00:15] [DEBUG] [Customers API Lite]
+[2026-02-15][18:00:15] [INFO ] HikariPool-1 - Starting...
+[2026-02-15][18:00:15] [INFO ] HikariPool-1 - Added connection org.sqlite.jdbc4.JDBC4Connection@50bb1c1f
+[2026-02-15][18:00:15] [INFO ] HikariPool-1 - Start completed.
+[2026-02-15][18:00:15] [DEBUG] [HikariProxyConnection@1540140763 wrapping org.sqlite.jdbc4.JDBC4Connection@50bb1c1f]
+[2026-02-15][18:00:15] [INFO ] Server started on port 8765
+[2026-02-15][18:10:20] [DEBUG] [PUT]
+[2026-02-15][18:10:20] [DEBUG] [Saturday Sunday]
+[2026-02-15][18:10:20] [DEBUG] [5|Saturday Sunday]
+[2026-02-15][18:10:25] [DEBUG] [PUT]
+[2026-02-15][18:10:25] [DEBUG] customer_id=5
+[2026-02-15][18:10:25] [DEBUG] [Saturday.Sunday@example.com]
+[2026-02-15][18:10:25] [DEBUG] [email|Saturday.Sunday@example.com]
+[2026-02-15][18:10:30] [DEBUG] [GET]
+[2026-02-15][18:10:30] [DEBUG] customer_id=5
+[2026-02-15][18:10:30] [DEBUG] [5|Saturday Sunday]
+[2026-02-15][18:10:35] [DEBUG] [GET]
+[2026-02-15][18:10:35] [DEBUG] customer_id=5 | contact_type=email
+[2026-02-15][18:10:35] [DEBUG] [Saturday.Sunday@example.com]
+```
+
+And of course, Docker itself gives the possibility to read log messages by using the corresponding command for that:
+
+```
+$ sudo docker logs -f api-lite-clj
+[2026-02-15][18:00:15] [DEBUG] [Customers API Lite]
+[2026-02-15][18:00:15] [INFO ] HikariPool-1 - Starting...
+[2026-02-15][18:00:15] [INFO ] HikariPool-1 - Added connection org.sqlite.jdbc4.JDBC4Connection@50bb1c1f
+[2026-02-15][18:00:15] [INFO ] HikariPool-1 - Start completed.
+[2026-02-15][18:00:15] [DEBUG] [HikariProxyConnection@1540140763 wrapping org.sqlite.jdbc4.JDBC4Connection@50bb1c1f]
+[2026-02-15][18:00:15] [INFO ] Server started on port 8765
+[2026-02-15][18:10:20] [DEBUG] [PUT]
+[2026-02-15][18:10:20] [DEBUG] [Saturday Sunday]
+[2026-02-15][18:10:20] [DEBUG] [5|Saturday Sunday]
+[2026-02-15][18:10:25] [DEBUG] [PUT]
+[2026-02-15][18:10:25] [DEBUG] customer_id=5
+[2026-02-15][18:10:25] [DEBUG] [Saturday.Sunday@example.com]
+[2026-02-15][18:10:25] [DEBUG] [email|Saturday.Sunday@example.com]
+[2026-02-15][18:10:30] [DEBUG] [GET]
+[2026-02-15][18:10:30] [DEBUG] customer_id=5
+[2026-02-15][18:10:30] [DEBUG] [5|Saturday Sunday]
+[2026-02-15][18:10:35] [DEBUG] [GET]
+[2026-02-15][18:10:35] [DEBUG] customer_id=5 | contact_type=email
+[2026-02-15][18:10:35] [DEBUG] [Saturday.Sunday@example.com]
+[2026-02-15][18:20:40] [INFO ] Server stopped
+[2026-02-15][18:20:40] [INFO ] HikariPool-1 - Shutdown initiated...
+[2026-02-15][18:20:40] [INFO ] HikariPool-1 - Shutdown completed.
+```
 
 ### Error handling
 

--- a/README.md
+++ b/README.md
@@ -331,28 +331,28 @@ The microservice has the ability to log messages to a logfile and to the Unix sy
 
 ```
 $ tail -f log/customers-api-lite.log
-[2026-02-13][15:10:00] [DEBUG] [Customers API Lite]
-[2026-02-13][15:10:00] [INFO ] HikariPool-1 - Starting...
-[2026-02-13][15:10:00] [INFO ] HikariPool-1 - Added connection org.sqlite.jdbc4.JDBC4Connection@7981963f
-[2026-02-13][15:10:00] [INFO ] HikariPool-1 - Start completed.
-[2026-02-13][15:10:00] [DEBUG] [HikariProxyConnection@401366570 wrapping org.sqlite.jdbc4.JDBC4Connection@7981963f]
-[2026-02-13][15:10:00] [INFO ] Server started on port 8765
-[2026-02-13][15:10:30] [DEBUG] [PUT]
-[2026-02-13][15:10:30] [DEBUG] [Saturday Sunday]
-[2026-02-13][15:10:30] [DEBUG] [5|Saturday Sunday]
-[2026-02-13][15:10:50] [DEBUG] [PUT]
-[2026-02-13][15:10:50] [DEBUG] customer_id=5
-[2026-02-13][15:10:50] [DEBUG] [Saturday.Sunday@example.com]
-[2026-02-13][15:10:50] [DEBUG] [email|Saturday.Sunday@example.com]
-[2026-02-13][15:11:10] [DEBUG] [GET]
-[2026-02-13][15:11:10] [DEBUG] customer_id=5
-[2026-02-13][15:11:10] [DEBUG] [5|Saturday Sunday]
-[2026-02-13][15:11:40] [DEBUG] [GET]
-[2026-02-13][15:11:40] [DEBUG] customer_id=5 | contact_type=email
-[2026-02-13][15:11:40] [DEBUG] [Saturday.Sunday@example.com]
-[2026-02-13][15:12:00] [INFO ] Server stopped
-[2026-02-13][15:12:00] [INFO ] HikariPool-1 - Shutdown initiated...
-[2026-02-13][15:12:00] [INFO ] HikariPool-1 - Shutdown completed.
+[2026-02-15][15:10:00] [DEBUG] [Customers API Lite]
+[2026-02-15][15:10:00] [INFO ] HikariPool-1 - Starting...
+[2026-02-15][15:10:00] [INFO ] HikariPool-1 - Added connection org.sqlite.jdbc4.JDBC4Connection@7109b603
+[2026-02-15][15:10:00] [INFO ] HikariPool-1 - Start completed.
+[2026-02-15][15:10:00] [DEBUG] [HikariProxyConnection@1040733616 wrapping org.sqlite.jdbc4.JDBC4Connection@7109b603]
+[2026-02-15][15:10:00] [INFO ] Server started on port 8765
+[2026-02-15][15:10:30] [DEBUG] [PUT]
+[2026-02-15][15:10:30] [DEBUG] [Saturday Sunday]
+[2026-02-15][15:10:30] [DEBUG] [5|Saturday Sunday]
+[2026-02-15][15:10:50] [DEBUG] [PUT]
+[2026-02-15][15:10:50] [DEBUG] customer_id=5
+[2026-02-15][15:10:50] [DEBUG] [Saturday.Sunday@example.com]
+[2026-02-15][15:10:50] [DEBUG] [email|Saturday.Sunday@example.com]
+[2026-02-15][15:11:10] [DEBUG] [GET]
+[2026-02-15][15:11:10] [DEBUG] customer_id=5
+[2026-02-15][15:11:10] [DEBUG] [5|Saturday Sunday]
+[2026-02-15][15:11:40] [DEBUG] [GET]
+[2026-02-15][15:11:40] [DEBUG] customer_id=5 | contact_type=email
+[2026-02-15][15:11:40] [DEBUG] [Saturday.Sunday@example.com]
+[2026-02-15][15:12:00] [INFO ] Server stopped
+[2026-02-15][15:12:00] [INFO ] HikariPool-1 - Shutdown initiated...
+[2026-02-15][15:12:00] [INFO ] HikariPool-1 - Shutdown completed.
 ```
 
 Messages registered by the Unix system logger can be seen and analyzed using the `journalctl` utility:
@@ -360,23 +360,23 @@ Messages registered by the Unix system logger can be seen and analyzed using the
 ```
 $ journalctl -f
 ...
-Feb 13 15:10:00 <hostname> java[<pid>]: [Customers API Lite]
-Feb 13 15:10:00 <hostname> java[<pid>]: [HikariProxyConnection@401366570 wrapping org.sqlite.jdbc4.JDBC4Connection@7981963f]
-Feb 13 15:10:00 <hostname> java[<pid>]: Server started on port 8765
-Feb 13 15:10:30 <hostname> java[<pid>]: [PUT]
-Feb 13 15:10:30 <hostname> java[<pid>]: [Saturday Sunday]
-Feb 13 15:10:30 <hostname> java[<pid>]: [5|Saturday Sunday]
-Feb 13 15:10:50 <hostname> java[<pid>]: [PUT]
-Feb 13 15:10:50 <hostname> java[<pid>]: customer_id=5
-Feb 13 15:10:50 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
-Feb 13 15:10:50 <hostname> java[<pid>]: [email|Saturday.Sunday@example.com]
-Feb 13 15:11:10 <hostname> java[<pid>]: [GET]
-Feb 13 15:11:10 <hostname> java[<pid>]: customer_id=5
-Feb 13 15:11:10 <hostname> java[<pid>]: [5|Saturday Sunday]
-Feb 13 15:11:40 <hostname> java[<pid>]: [GET]
-Feb 13 15:11:40 <hostname> java[<pid>]: customer_id=5 | contact_type=email
-Feb 13 15:11:40 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
-Feb 13 15:12:00 <hostname> java[<pid>]: Server stopped
+Feb 15 15:10:00 <hostname> java[<pid>]: [Customers API Lite]
+Feb 15 15:10:00 <hostname> java[<pid>]: [HikariProxyConnection@1040733616 wrapping org.sqlite.jdbc4.JDBC4Connection@7109b603]
+Feb 15 15:10:00 <hostname> java[<pid>]: Server started on port 8765
+Feb 15 15:10:30 <hostname> java[<pid>]: [PUT]
+Feb 15 15:10:30 <hostname> java[<pid>]: [Saturday Sunday]
+Feb 15 15:10:30 <hostname> java[<pid>]: [5|Saturday Sunday]
+Feb 15 15:10:50 <hostname> java[<pid>]: [PUT]
+Feb 15 15:10:50 <hostname> java[<pid>]: customer_id=5
+Feb 15 15:10:50 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
+Feb 15 15:10:50 <hostname> java[<pid>]: [email|Saturday.Sunday@example.com]
+Feb 15 15:11:10 <hostname> java[<pid>]: [GET]
+Feb 15 15:11:10 <hostname> java[<pid>]: customer_id=5
+Feb 15 15:11:10 <hostname> java[<pid>]: [5|Saturday Sunday]
+Feb 15 15:11:40 <hostname> java[<pid>]: [GET]
+Feb 15 15:11:40 <hostname> java[<pid>]: customer_id=5 | contact_type=email
+Feb 15 15:11:40 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
+Feb 15 15:12:00 <hostname> java[<pid>]: Server stopped
 ```
 
 **TBD** :cd:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.2.6.jar > /dev/null 2>&1
+[1]+  Exit 143                   java -jar target/uberjar/customers-api-lite-0.2.6.jar > /dev/null 2>&1
 ```
 
 ## Consuming
@@ -285,28 +285,28 @@ The microservice has the ability to log messages to a logfile and to the Unix sy
 
 ```
 $ tail -f log/customers-api-lite.log
-[2025-12-31][00:10:00] [DEBUG] [Customers API Lite]
-[2025-12-31][00:10:00] [INFO ] HikariPool-1 - Starting...
-[2025-12-31][00:10:00] [INFO ] HikariPool-1 - Added connection org.sqlite.jdbc4.JDBC4Connection@56a09a5c
-[2025-12-31][00:10:00] [INFO ] HikariPool-1 - Start completed.
-[2025-12-31][00:10:00] [DEBUG] [HikariProxyConnection@1198265211 wrapping org.sqlite.jdbc4.JDBC4Connection@56a09a5c]
-[2025-12-31][00:10:00] [INFO ] Server started on port 8765
-[2025-12-31][00:10:30] [DEBUG] [PUT]
-[2025-12-31][00:10:30] [DEBUG] [Saturday Sunday]
-[2025-12-31][00:10:30] [DEBUG] [5|Saturday Sunday]
-[2025-12-31][00:10:50] [DEBUG] [PUT]
-[2025-12-31][00:10:50] [DEBUG] customer_id=5
-[2025-12-31][00:10:50] [DEBUG] [Saturday.Sunday@example.com]
-[2025-12-31][00:10:50] [DEBUG] [email|Saturday.Sunday@example.com]
-[2025-12-31][00:11:10] [DEBUG] [GET]
-[2025-12-31][00:11:10] [DEBUG] customer_id=5
-[2025-12-31][00:11:10] [DEBUG] [5|Saturday Sunday]
-[2025-12-31][00:11:40] [DEBUG] [GET]
-[2025-12-31][00:11:40] [DEBUG] customer_id=5 | contact_type=email
-[2025-12-31][00:11:40] [DEBUG] [Saturday.Sunday@example.com]
-[2025-12-31][00:12:00] [INFO ] Server stopped
-[2025-12-31][00:12:00] [INFO ] HikariPool-1 - Shutdown initiated...
-[2025-12-31][00:12:00] [INFO ] HikariPool-1 - Shutdown completed.
+[2026-02-13][15:10:00] [DEBUG] [Customers API Lite]
+[2026-02-13][15:10:00] [INFO ] HikariPool-1 - Starting...
+[2026-02-13][15:10:00] [INFO ] HikariPool-1 - Added connection org.sqlite.jdbc4.JDBC4Connection@7981963f
+[2026-02-13][15:10:00] [INFO ] HikariPool-1 - Start completed.
+[2026-02-13][15:10:00] [DEBUG] [HikariProxyConnection@401366570 wrapping org.sqlite.jdbc4.JDBC4Connection@7981963f]
+[2026-02-13][15:10:00] [INFO ] Server started on port 8765
+[2026-02-13][15:10:30] [DEBUG] [PUT]
+[2026-02-13][15:10:30] [DEBUG] [Saturday Sunday]
+[2026-02-13][15:10:30] [DEBUG] [5|Saturday Sunday]
+[2026-02-13][15:10:50] [DEBUG] [PUT]
+[2026-02-13][15:10:50] [DEBUG] customer_id=5
+[2026-02-13][15:10:50] [DEBUG] [Saturday.Sunday@example.com]
+[2026-02-13][15:10:50] [DEBUG] [email|Saturday.Sunday@example.com]
+[2026-02-13][15:11:10] [DEBUG] [GET]
+[2026-02-13][15:11:10] [DEBUG] customer_id=5
+[2026-02-13][15:11:10] [DEBUG] [5|Saturday Sunday]
+[2026-02-13][15:11:40] [DEBUG] [GET]
+[2026-02-13][15:11:40] [DEBUG] customer_id=5 | contact_type=email
+[2026-02-13][15:11:40] [DEBUG] [Saturday.Sunday@example.com]
+[2026-02-13][15:12:00] [INFO ] Server stopped
+[2026-02-13][15:12:00] [INFO ] HikariPool-1 - Shutdown initiated...
+[2026-02-13][15:12:00] [INFO ] HikariPool-1 - Shutdown completed.
 ```
 
 Messages registered by the Unix system logger can be seen and analyzed using the `journalctl` utility:
@@ -314,23 +314,23 @@ Messages registered by the Unix system logger can be seen and analyzed using the
 ```
 $ journalctl -f
 ...
-Dec 31 00:10:00 <hostname> java[<pid>]: [Customers API Lite]
-Dec 31 00:10:00 <hostname> java[<pid>]: [HikariProxyConnection@1198265211 wrapping org.sqlite.jdbc4.JDBC4Connection@56a09a5c]
-Dec 31 00:10:00 <hostname> java[<pid>]: Server started on port 8765
-Dec 31 00:10:30 <hostname> java[<pid>]: [PUT]
-Dec 31 00:10:30 <hostname> java[<pid>]: [Saturday Sunday]
-Dec 31 00:10:30 <hostname> java[<pid>]: [5|Saturday Sunday]
-Dec 31 00:10:50 <hostname> java[<pid>]: [PUT]
-Dec 31 00:10:50 <hostname> java[<pid>]: customer_id=5
-Dec 31 00:10:50 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
-Dec 31 00:10:50 <hostname> java[<pid>]: [email|Saturday.Sunday@example.com]
-Dec 31 00:11:10 <hostname> java[<pid>]: [GET]
-Dec 31 00:11:10 <hostname> java[<pid>]: customer_id=5
-Dec 31 00:11:10 <hostname> java[<pid>]: [5|Saturday Sunday]
-Dec 31 00:11:40 <hostname> java[<pid>]: [GET]
-Dec 31 00:11:40 <hostname> java[<pid>]: customer_id=5 | contact_type=email
-Dec 31 00:11:40 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
-Dec 31 00:12:00 <hostname> java[<pid>]: Server stopped
+Feb 13 15:10:00 <hostname> java[<pid>]: [Customers API Lite]
+Feb 13 15:10:00 <hostname> java[<pid>]: [HikariProxyConnection@401366570 wrapping org.sqlite.jdbc4.JDBC4Connection@7981963f]
+Feb 13 15:10:00 <hostname> java[<pid>]: Server started on port 8765
+Feb 13 15:10:30 <hostname> java[<pid>]: [PUT]
+Feb 13 15:10:30 <hostname> java[<pid>]: [Saturday Sunday]
+Feb 13 15:10:30 <hostname> java[<pid>]: [5|Saturday Sunday]
+Feb 13 15:10:50 <hostname> java[<pid>]: [PUT]
+Feb 13 15:10:50 <hostname> java[<pid>]: customer_id=5
+Feb 13 15:10:50 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
+Feb 13 15:10:50 <hostname> java[<pid>]: [email|Saturday.Sunday@example.com]
+Feb 13 15:11:10 <hostname> java[<pid>]: [GET]
+Feb 13 15:11:10 <hostname> java[<pid>]: customer_id=5
+Feb 13 15:11:10 <hostname> java[<pid>]: [5|Saturday Sunday]
+Feb 13 15:11:40 <hostname> java[<pid>]: [GET]
+Feb 13 15:11:40 <hostname> java[<pid>]: customer_id=5 | contact_type=email
+Feb 13 15:11:40 <hostname> java[<pid>]: [Saturday.Sunday@example.com]
+Feb 13 15:12:00 <hostname> java[<pid>]: Server stopped
 ```
 
 **TBD** :cd:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ Surely, one may consider this project to be suitable for a wide variety of appli
 
 ## Building
 
-The microservice might be built and run successfully under **Arch Linux** (proven). &mdash; First install the necessary dependencies (`jdk21-openjdk`, `leiningen`, `make`, `docker`):
+The microservice might be built and run successfully under **Ubuntu Server (Ubuntu 24.04.4 LTS x86-64)** and **Arch Linux** (both proven). &mdash; First install the necessary dependencies (`openjdk-21-jdk-headless`, `leiningen`, `make`, `docker.io`):
+
+* In Ubuntu Server:
+
+```
+$ sudo apt-get update && \
+  sudo apt-get install openjdk-21-jdk-headless leiningen make docker.io -y
+...
+```
+
+* In Arch Linux:
 
 ```
 $ sudo pacman -Syu jdk21-openjdk leiningen make docker
@@ -116,7 +126,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                   java -jar target/uberjar/customers-api-lite-0.2.6.jar > /dev/null 2>&1
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.2.6.jar > /dev/null 2>&1
 ```
 
 ## Consuming

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Surely, one may consider this project to be suitable for a wide variety of appli
 ## Table of Contents
 
 * **[Building](#building)**
+  * **[Creating a Docker image](#creating-a-docker-image)**
 * **[Running](#running)**
+  * **[Running a Docker image](#running-a-docker-image)**
+  * **[Exploring a Docker image payload](#exploring-a-docker-image-payload)**
 * **[Consuming](#consuming)**
   * **[Logging](#logging)**
   * **[Error handling](#error-handling)**
@@ -96,6 +99,19 @@ $ make all  # <== Building the daemon (executable JAR bundle).
 ...
 ```
 
+### Creating a Docker image
+
+**Build** a Docker image for the microservice:
+
+```
+$ # Pull the Azul Zulu JRE image first (based on Alpine Linux), if not already there:
+$ sudo docker pull azul/zulu-openjdk-alpine:21-jre-headless-latest
+...
+$ # Then build the microservice image:
+$ sudo docker build -tcustomersapi/api-lite-clj .
+...
+```
+
 ## Running
 
 **Run** the microservice using **Leiningen** (recompiling sources on-the-fly, if required):
@@ -128,6 +144,26 @@ $ kill -SIGTERM <pid>
 $
 [1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.2.6.jar > /dev/null 2>&1
 ```
+
+### Running a Docker image
+
+**Run** a Docker image of the microservice, deleting all stopped containers prior to that (if any):
+
+```
+$ sudo docker rm `sudo docker ps -aq`; \
+  export PORT=8765 && sudo docker run -dp${PORT}:${PORT} --name api-lite-clj customersapi/api-lite-clj; echo $?
+...
+```
+
+### Exploring a Docker image payload
+
+```
+$ sudo docker ps -a
+CONTAINER ID   IMAGE                       COMMAND                   CREATED              STATUS              PORTS                                         NAMES
+<container_id> customersapi/api-lite-clj   "java -jar api-lite..."   About a minute ago   Up About a minute   0.0.0.0:8765->8765/tcp, [::]:8765->8765/tcp   api-lite-clj
+```
+
+**TBD** :cd:
 
 ## Consuming
 

--- a/README.md
+++ b/README.md
@@ -157,13 +157,67 @@ $ sudo docker rm `sudo docker ps -aq`; \
 
 ### Exploring a Docker image payload
 
+The following is not necessary but might be considered somewhat interesting &mdash; to look into the running container and check out that the microservice's executable JAR bundle, logfile, and accompanied SQLite database are at their expected places and in effect:
+
 ```
 $ sudo docker ps -a
 CONTAINER ID   IMAGE                       COMMAND                   CREATED              STATUS              PORTS                                         NAMES
 <container_id> customersapi/api-lite-clj   "java -jar api-lite..."   About a minute ago   Up About a minute   0.0.0.0:8765->8765/tcp, [::]:8765->8765/tcp   api-lite-clj
-```
+$
+$ sudo docker exec -it api-lite-clj sh; echo $?
+/var/tmp/api-lite $
+/var/tmp/api-lite $ uname -a
+Linux <container_id> 6.8.0-100-generic #100-Ubuntu SMP PREEMPT_DYNAMIC Tue Jan 13 16:40:06 UTC 2026 x86_64 Linux
+/var/tmp/api-lite $
+/var/tmp/api-lite $ cat /etc/os-release /etc/alpine-release
+NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.20.9
+PRETTY_NAME="Alpine Linux v3.20"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
+3.20.9
+/var/tmp/api-lite $
+/var/tmp/api-lite $ java --version
+openjdk 21.0.10 2026-01-20 LTS
+OpenJDK Runtime Environment Zulu21.48+17-CA (build 21.0.10+7-LTS)
+OpenJDK 64-Bit Server VM Zulu21.48+17-CA (build 21.0.10+7-LTS, mixed mode, sharing)
+/var/tmp/api-lite $
+/var/tmp/api-lite $ ls -al
+total 26348
+drwxr-xr-x    1 daemon   daemon        4096 Feb 15 18:00 .
+drwxrwxrwt    1 root     root          4096 Feb 15 10:10 ..
+-rw-rw-r--    1 daemon   daemon    26949863 Feb 15 10:00 api-lite.jar
+drwxr-xr-x    1 daemon   daemon        4096 Feb 15 10:10 data
+drwxr-xr-x    2 daemon   daemon        4096 Feb 15 18:00 log
+/var/tmp/api-lite $
+/var/tmp/api-lite $ ls -al data/db/ log/
+data/db/:
+total 40
+drwxr-xr-x    1 daemon   daemon        4096 Feb 15 10:10 .
+drwxr-xr-x    1 daemon   daemon        4096 Feb 15 10:10 ..
+-rw-rw-r--    1 daemon   daemon       24576 Feb 15 09:40 customers-api-lite.db
 
-**TBD** :cd:
+log/:
+total 16
+drwxr-xr-x    2 daemon   daemon        4096 Feb 15 18:00 .
+drwxr-xr-x    1 daemon   daemon        4096 Feb 15 18:00 ..
+-rw-r--r--    1 daemon   daemon         454 Feb 15 18:00 customers-api-lite.log
+/var/tmp/api-lite $
+/var/tmp/api-lite $ netstat -plunt
+Active Internet connections (only servers)
+Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
+tcp        0      0 :::8765                 :::*                    LISTEN      1/java
+/var/tmp/api-lite $
+/var/tmp/api-lite $ ps aux
+PID   USER     TIME  COMMAND
+    1 daemon    0:10 java -jar api-lite.jar
+   25 daemon    0:00 sh
+   48 daemon    0:00 ps aux
+/var/tmp/api-lite $
+/var/tmp/api-lite $ exit # Or simply <Ctrl-D>.
+0
+```
 
 ## Consuming
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,14 @@ PID   USER     TIME  COMMAND
 0
 ```
 
+To stop a running container of the microservice gracefully at any time, simply issue the following command:
+
+```
+$ sudo docker stop api-lite-clj; echo $?
+api-lite-clj
+0
+```
+
 ## Consuming
 
 The microservice exposes **six REST API endpoints** to web clients. They are all intended to deal with customer entities and/or contact entities that belong to customer profiles. The following table displays their syntax:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $
 $ lein uberjar && \
   UBERJAR_DIR="target/uberjar"; \
   DAEMON_NAME="customers-api-lite"; \
-  DMN_VERSION="0.2.6"; \
+  DMN_VERSION="0.3.0"; \
   SIMPLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}.jar"; \
   BUNDLE_JAR="${UBERJAR_DIR}/${DAEMON_NAME}-${DMN_VERSION}-standalone.jar"; \
   rm ${SIMPLE_JAR} && mv ${BUNDLE_JAR} ${SIMPLE_JAR} && \
@@ -84,8 +84,8 @@ Compiling customers.api-lite.controller
 Compiling customers.api-lite.core
 Compiling customers.api-lite.helper
 Compiling customers.api-lite.model
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.2.6.jar
-Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.2.6-standalone.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.3.0.jar
+Created $HOME/customers-api-proto-lite-clojure-httpkit/target/uberjar/customers-api-lite-0.3.0-standalone.jar
 ```
 
 Or **build** the microservice using **GNU Make** (optional, but for convenience &mdash; it covers the same **Leiningen** build workflow under the hood):
@@ -124,14 +124,14 @@ $ lein run; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `uberjar` Leiningen task or GNU Make's `all` target:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.2.6.jar; echo $?
+$ java -jar target/uberjar/customers-api-lite-0.3.0.jar; echo $?
 ...
 ```
 
 To run the microservice as a *true* daemon, i.e. in the background, redirecting all the console output to `/dev/null`, the following form of invocation of its executable JAR bundle can be used:
 
 ```
-$ java -jar target/uberjar/customers-api-lite-0.2.6.jar > /dev/null 2>&1 &
+$ java -jar target/uberjar/customers-api-lite-0.3.0.jar > /dev/null 2>&1 &
 [1] <pid>
 ```
 
@@ -142,7 +142,7 @@ The daemonized microservice then can be stopped gracefully at any time by issuin
 ```
 $ kill -SIGTERM <pid>
 $
-[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.2.6.jar > /dev/null 2>&1
+[1]+  Exit 143                java -jar target/uberjar/customers-api-lite-0.3.0.jar > /dev/null 2>&1
 ```
 
 ### Running a Docker image

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+-- Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 -- ============================================================================
 -- A daemon written in Clojure, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype
@@ -10,7 +10,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject customers-api-lite "0.2.6"
+(defproject customers-api-lite "0.3.0"
     :description     "Customers API Lite microservice prototype."
     :url             "https://github.com/rgolubtsov/customers-api-proto-lite-clojure-httpkit"
     :license {

--- a/src/customers/api_lite/controller.clj
+++ b/src/customers/api_lite/controller.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/controller.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/core.clj
+++ b/src/customers/api_lite/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/core.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/helper.clj
+++ b/src/customers/api_lite/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/helper.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/customers/api_lite/model.clj
+++ b/src/customers/api_lite/model.clj
@@ -1,7 +1,7 @@
 ;
 ; src/customers/api_lite/model.clj
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+# Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/resources/settings.conf
+++ b/src/resources/settings.conf
@@ -1,7 +1,7 @@
 ;
 ; src/resources/settings.conf
 ; =============================================================================
-; Customers API Lite microservice prototype (Clojure port). Version 0.2.6
+; Customers API Lite microservice prototype (Clojure port). Version 0.3.0
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- Claiming that the microservice has been successfully tested (built and run) under **Ubuntu Server 24.04.4 LTS x86-64**.
- Updating log entries after running the daemon under Ubuntu Server (_not in a Docker container_).
- Adding the `Dockerfile` for the microservice.
- Writing subsections **"Creating a Docker image"**, **"Running a Docker image"**, and **"Exploring a Docker image payload"** in the docs.
- Exposing log entries when running the daemon _in a Docker container_.
- Showing how to stop a running container of the microservice gracefully.
- Bumping version number to **0.3.0**.